### PR TITLE
feat(ci): add multi-platform Docker builds for amd64 and arm64 🐳

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,12 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Docker images
+      - name: Build and push Docker images (multi-platform)
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ steps.ghcr_meta.outputs.tags }}


### PR DESCRIPTION
## What I changed and personal note 🌟

- Added **multi-platform Docker builds** for `linux/amd64` and `linux/arm64`
- Flare now builds images that slay on **servers, Raspberry Pis, and more**! Yaaay! 🐳

> [!NOTE]
> I was **annoyed** having to build my own arm images and flare deserved better but so did I.  
> So I added multi-platform support myself, like the royalty I am.
>
> Jk but seriously, I need this for ARM on your official repo, I tested the arm build on my local, and it is running well.

---

## 🔧 Technical Details

- Updated `build-push-action` to include:
  ```yaml
  platforms: linux/amd64,linux/arm64
