### PR TITLE
Support setting default options for file expiry

### DIFF
--- a/app/(main)/dashboard/profile/page.tsx
+++ b/app/(main)/dashboard/profile/page.tsx
@@ -29,6 +29,8 @@ export default async function ProfilePage() {
       role: true,
       randomizeFileUrls: true,
       enableRichEmbeds: true,
+      defaultFileExpirationAction: true,
+      defaultFileExpiration: true,
       urlId: true,
       _count: {
         select: { files: true, shortenedUrls: true },
@@ -82,6 +84,8 @@ export default async function ProfilePage() {
               urlId: user.urlId,
               fileCount: user._count.files,
               shortUrlCount: user._count.shortenedUrls,
+              defaultFileExpiration: user.defaultFileExpiration,
+              defaultFileExpirationAction: user.defaultFileExpirationAction,
             }}
             quotasEnabled={quotasEnabled}
             formattedQuota={formattedQuota}

--- a/app/(main)/dashboard/upload/page.tsx
+++ b/app/(main)/dashboard/upload/page.tsx
@@ -6,12 +6,26 @@ import { UploadForm } from '@/components/file/upload-form'
 
 import { authOptions } from '@/lib/auth'
 import { getConfig } from '@/lib/config'
+import { prisma } from '@/lib/database/prisma'
 import { formatBytes } from '@/lib/utils'
 
 export default async function UploadPage() {
   const session = await getServerSession(authOptions)
 
   if (!session?.user) {
+    redirect('/auth/login')
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      id: true,
+      defaultFileExpirationAction: true,
+      defaultFileExpiration: true,
+    },
+  })
+
+  if (!user) {
     redirect('/auth/login')
   }
 
@@ -37,6 +51,7 @@ export default async function UploadPage() {
         <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-white/10 via-transparent to-black/5 dark:from-white/5 dark:via-transparent dark:to-black/10" />
         <div className="relative p-8">
           <UploadForm
+            user={user}
             maxSize={maxSizeBytes}
             formattedMaxSize={formattedMaxSize}
           />

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -73,6 +73,10 @@ export async function PUT(req: Request) {
       updateData.randomizeFileUrls = body.randomizeFileUrls
     if (typeof body.enableRichEmbeds === 'boolean')
       updateData.enableRichEmbeds = body.enableRichEmbeds
+    if (body.defaultFileExpiration)
+      updateData.defaultFileExpiration = body.defaultFileExpiration
+    if (body.defaultFileExpirationAction)
+      updateData.defaultFileExpirationAction = body.defaultFileExpirationAction
 
     const updatedUser = await prisma.user.update({
       where: { id: user.id },

--- a/components/file/upload-form.tsx
+++ b/components/file/upload-form.tsx
@@ -45,7 +45,7 @@ interface UploadFormProps {
 }
 
 const getDefaultExpiryDate = (unit: $Enums.FileExpiration | null) => {
-  if (!unit) return undefined
+  if (!unit || unit === 'DISABLED') return undefined
 
   const date = new Date()
 
@@ -101,9 +101,6 @@ export function UploadForm({
     onDrop,
     maxSize,
   })
-
-  if (user.defaultFileExpiration) {
-  }
 
   return (
     <div className="space-y-8">

--- a/components/profile/account/profile-account.tsx
+++ b/components/profile/account/profile-account.tsx
@@ -11,6 +11,13 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 
 import { useToast } from '@/hooks/use-toast'
@@ -129,7 +136,11 @@ export function ProfileAccount({ user, onUpdate }: ProfileAccountProps) {
     }
   }
 
-  const handleRandomizeUrlsToggle = async (checked: boolean) => {
+  const handleValueChange = async (
+    value: boolean | string,
+    key: string,
+    description: string
+  ) => {
     setIsLoading(true)
     try {
       const response = await fetch('/api/profile', {
@@ -138,7 +149,7 @@ export function ProfileAccount({ user, onUpdate }: ProfileAccountProps) {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          randomizeFileUrls: checked,
+          [key]: value,
         }),
       })
 
@@ -153,45 +164,7 @@ export function ProfileAccount({ user, onUpdate }: ProfileAccountProps) {
 
       toast({
         title: 'Success',
-        description: 'File URL settings updated successfully',
-      })
-    } catch (error) {
-      toast({
-        title: 'Error',
-        description:
-          error instanceof Error ? error.message : 'Failed to update settings',
-        variant: 'destructive',
-      })
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  const handleRichEmbedsToggle = async (checked: boolean) => {
-    setIsLoading(true)
-    try {
-      const response = await fetch('/api/profile', {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          enableRichEmbeds: checked,
-        }),
-      })
-
-      if (!response.ok) {
-        const data = await response.json()
-        throw new Error(data.error || 'Failed to update settings')
-      }
-
-      router.refresh()
-
-      onUpdate()
-
-      toast({
-        title: 'Success',
-        description: 'Rich embed settings updated successfully',
+        description: description,
       })
     } catch (error) {
       toast({
@@ -286,7 +259,13 @@ export function ProfileAccount({ user, onUpdate }: ProfileAccountProps) {
         <Switch
           id="randomize-urls"
           checked={user.randomizeFileUrls}
-          onCheckedChange={handleRandomizeUrlsToggle}
+          onCheckedChange={(c) =>
+            handleValueChange(
+              c,
+              'randomizeFileUrls',
+              'File URL settings updated successfully'
+            )
+          }
           disabled={isLoading}
         />
       </div>
@@ -302,9 +281,75 @@ export function ProfileAccount({ user, onUpdate }: ProfileAccountProps) {
         <Switch
           id="rich-embeds"
           checked={user.enableRichEmbeds}
-          onCheckedChange={handleRichEmbedsToggle}
+          onCheckedChange={(v) =>
+            handleValueChange(
+              v,
+              'enableRichEmbeds',
+              'Rich embed settings updated successfully'
+            )
+          }
           disabled={isLoading}
         />
+      </div>
+
+      <div className="flex items-center justify-between rounded-lg border p-4 mt-4">
+        <div className="space-y-0.5">
+          <Label>Default file expiry action</Label>
+          <p className="text-sm text-muted-foreground">
+            Set the default file expiry action when creating a new upload
+          </p>
+        </div>
+        <div className="w-1/4 ml-auto">
+          <Select
+            value={user.defaultFileExpirationAction ?? undefined}
+            onValueChange={(v) =>
+              handleValueChange(
+                v,
+                'defaultFileExpirationAction',
+                'Default file expiration action updated successfully'
+              )
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="DELETE">Delete file</SelectItem>
+              <SelectItem value="SET_PRIVATE">Set to private</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between rounded-lg border p-4 mt-4">
+        <div className="space-y-0.5">
+          <Label>Default file expiry time</Label>
+          <p className="text-sm text-muted-foreground">
+            Set the default relative time before an upload expires
+          </p>
+        </div>
+        <div className="w-1/4 ml-auto">
+          <Select
+            value={user.defaultFileExpiration ?? undefined}
+            onValueChange={(v) =>
+              handleValueChange(
+                v,
+                'defaultFileExpiration',
+                'Default file expiration time updated successfully'
+              )
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="DAY">One hour</SelectItem>
+              <SelectItem value="HOUR">One day</SelectItem>
+              <SelectItem value="WEEK">One week</SelectItem>
+              <SelectItem value="MONTH">One month</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </div>
     </>
   )

--- a/components/profile/account/profile-account.tsx
+++ b/components/profile/account/profile-account.tsx
@@ -343,6 +343,7 @@ export function ProfileAccount({ user, onUpdate }: ProfileAccountProps) {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value="DISABLED">Disabled</SelectItem>
               <SelectItem value="DAY">One hour</SelectItem>
               <SelectItem value="HOUR">One day</SelectItem>
               <SelectItem value="WEEK">One week</SelectItem>

--- a/prisma/migrations/20251004200125_default_file_expiration/migration.sql
+++ b/prisma/migrations/20251004200125_default_file_expiration/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+CREATE TYPE "public"."FileExpiration" AS ENUM ('HOUR', 'DAY', 'WEEK', 'MONTH');
+
+-- CreateEnum
+CREATE TYPE "public"."ExpiryAction" AS ENUM ('DELETE', 'SET_PRIVATE');
+
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "defaultFileExpiration" "public"."FileExpiration",
+ADD COLUMN     "defaultFileExpirationAction" "public"."ExpiryAction" NOT NULL DEFAULT 'DELETE';

--- a/prisma/migrations/20251004200125_default_file_expiration/migration.sql
+++ b/prisma/migrations/20251004200125_default_file_expiration/migration.sql
@@ -1,9 +1,9 @@
 -- CreateEnum
-CREATE TYPE "public"."FileExpiration" AS ENUM ('HOUR', 'DAY', 'WEEK', 'MONTH');
+CREATE TYPE "public"."FileExpiration" AS ENUM ('DISABLED', 'HOUR', 'DAY', 'WEEK', 'MONTH');
 
 -- CreateEnum
 CREATE TYPE "public"."ExpiryAction" AS ENUM ('DELETE', 'SET_PRIVATE');
 
 -- AlterTable
-ALTER TABLE "public"."User" ADD COLUMN     "defaultFileExpiration" "public"."FileExpiration",
+ALTER TABLE "public"."User" ADD COLUMN     "defaultFileExpiration" "public"."FileExpiration" NOT NULL DEFAULT 'DISABLED',
 ADD COLUMN     "defaultFileExpirationAction" "public"."ExpiryAction" NOT NULL DEFAULT 'DELETE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,26 +8,26 @@ datasource db {
 }
 
 model User {
-  id                          String          @id @default(cuid())
+  id                          String         @id @default(cuid())
   name                        String?
-  email                       String?         @unique
+  email                       String?        @unique
   emailVerified               DateTime?
   image                       String?
   password                    String?
-  role                        UserRole        @default(USER)
-  createdAt                   DateTime        @default(now())
-  updatedAt                   DateTime        @updatedAt
-  storageUsed                 Float           @default(0)
-  sessionVersion              Int             @default(1)
-  vanityId                    String?         @unique
-  urlId                       String          @unique
-  uploadToken                 String          @unique
-  randomizeFileUrls           Boolean         @default(false)
-  enableRichEmbeds            Boolean         @default(true)
+  role                        UserRole       @default(USER)
+  createdAt                   DateTime       @default(now())
+  updatedAt                   DateTime       @updatedAt
+  storageUsed                 Float          @default(0)
+  sessionVersion              Int            @default(1)
+  vanityId                    String?        @unique
+  urlId                       String         @unique
+  uploadToken                 String         @unique
+  randomizeFileUrls           Boolean        @default(false)
+  enableRichEmbeds            Boolean        @default(true)
   files                       File[]
   shortenedUrls               ShortenedUrl[]
-  defaultFileExpiration       FileExpiration?
-  defaultFileExpirationAction ExpiryAction    @default(DELETE)
+  defaultFileExpiration       FileExpiration @default(DISABLED)
+  defaultFileExpirationAction ExpiryAction   @default(DELETE)
 }
 
 model File {
@@ -124,6 +124,7 @@ enum EventStatus {
 }
 
 enum FileExpiration {
+  DISABLED
   HOUR
   DAY
   WEEK

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,24 +8,26 @@ datasource db {
 }
 
 model User {
-  id                String         @id @default(cuid())
-  name              String?
-  email             String?        @unique
-  emailVerified     DateTime?
-  image             String?
-  password          String?
-  role              UserRole       @default(USER)
-  createdAt         DateTime       @default(now())
-  updatedAt         DateTime       @updatedAt
-  storageUsed       Float          @default(0)
-  sessionVersion    Int            @default(1)
-  vanityId          String?        @unique
-  urlId             String         @unique
-  uploadToken       String         @unique
-  randomizeFileUrls Boolean        @default(false)
-  enableRichEmbeds  Boolean        @default(true)
-  files             File[]
-  shortenedUrls     ShortenedUrl[]
+  id                          String          @id @default(cuid())
+  name                        String?
+  email                       String?         @unique
+  emailVerified               DateTime?
+  image                       String?
+  password                    String?
+  role                        UserRole        @default(USER)
+  createdAt                   DateTime        @default(now())
+  updatedAt                   DateTime        @updatedAt
+  storageUsed                 Float           @default(0)
+  sessionVersion              Int             @default(1)
+  vanityId                    String?         @unique
+  urlId                       String          @unique
+  uploadToken                 String          @unique
+  randomizeFileUrls           Boolean         @default(false)
+  enableRichEmbeds            Boolean         @default(true)
+  files                       File[]
+  shortenedUrls               ShortenedUrl[]
+  defaultFileExpiration       FileExpiration?
+  defaultFileExpirationAction ExpiryAction    @default(DELETE)
 }
 
 model File {
@@ -119,4 +121,16 @@ enum EventStatus {
   COMPLETED
   FAILED
   SCHEDULED
+}
+
+enum FileExpiration {
+  HOUR
+  DAY
+  WEEK
+  MONTH
+}
+
+enum ExpiryAction {
+  DELETE
+  SET_PRIVATE
 }

--- a/types/components/user.ts
+++ b/types/components/user.ts
@@ -1,3 +1,5 @@
+import { ExpiryAction } from '@/types/events'
+
 export interface User {
   id: string
   name: string | null
@@ -10,6 +12,8 @@ export interface User {
   urlId: string
   fileCount: number
   shortUrlCount: number
+  defaultFileExpiration: 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | null
+  defaultFileExpirationAction: 'DELETE' | 'SET_PRIVATE' | null
 }
 
 export interface ProfileClientProps {

--- a/types/components/user.ts
+++ b/types/components/user.ts
@@ -12,7 +12,7 @@ export interface User {
   urlId: string
   fileCount: number
   shortUrlCount: number
-  defaultFileExpiration: 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | null
+  defaultFileExpiration: 'DISABLED' | 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | null
   defaultFileExpirationAction: 'DELETE' | 'SET_PRIVATE' | null
 }
 

--- a/types/dto/profile.ts
+++ b/types/dto/profile.ts
@@ -8,6 +8,8 @@ export const UpdateProfileSchema = z.object({
   image: z.string().optional(),
   randomizeFileUrls: z.boolean().optional(),
   enableRichEmbeds: z.boolean().optional(),
+  defaultFileExpiration: z.enum(['HOUR', 'DAY', 'WEEK', 'MONTH']).optional(),
+  defaultFileExpirationAction: z.enum(['DELETE', 'SET_PRIVATE']).optional(),
 })
 
 export type UpdateProfileRequest = z.infer<typeof UpdateProfileSchema>


### PR DESCRIPTION
## What does your PR do?

Adds new user preferences to allow default expiration options for file uploads

## Why are you making these changes?

These are features I personally need. I'm using flare to upload big screenshots I cannot upload to discord without nitro, and don't need these one of files staying on my server ever. So I'd like a default expiry

## How did you implement it?

Most likely not in the best way. I tried following patterns I saw elsewhere in the app, but I am not in my element. I do not use js/ts in the backend so that was all new libs for me. Not only that, but I'm also more used to Angular. I think ideally, there'd be a new entity UserPreferences which could host all preferences, as well as new ones. 

Also, this feature should probably have been expanded to include default values of the other functions. Wanting to gauge interest first. Let me know how you'd like to go about this. I'm happy to (try and) make the changes for all this. 

I personally do not need defaults for the others, so I'm more than happy to leave it at this as well 🙂 

## Screenshots / Recordings (if UI)

<img width="1191" height="211" alt="image" src="https://github.com/user-attachments/assets/38f0636d-f6de-412e-804e-08cabaf0e94c" />


## Related Issues

N/A

## Additional Info

The contribution guidelines were missing some info about bun being required. I was surprised to see the failure when trying to commit my changes 😀 
