### PR TITLE
Add docker-compose template for easy deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <div align="center">
   <img src="./public/banner.png" alt="Flare Banner" width="600px" />
   <p><small><i>Icon designed by <a href="https://ko-fi.com/xnefas/">xNefas</a></i></small></p>
@@ -45,7 +46,7 @@ Click the button below to deploy Flare on Railway. Once deployed, just set your 
 
 ### Docker Deployment (Self-Hosted)
 
-1. Set up a PostgreSQL server and create a database for Flare.
+1. Install ```docker.io``` and ```docker-compose```
 
 2. Create a `.env` file with the following required variables:
 
@@ -55,18 +56,47 @@ Click the button below to deploy Flare on Railway. Once deployed, just set your 
    NEXTAUTH_URL=http://localhost:3000 # (or wherever you deploy Flare)
    ```
 
-3. Run Flare using the pre-built Docker image:
+3. Create ```docker-compose.yml``` with the following template:
 
-   ```bash
-   docker run -d \
-     --name flare \
-     -p 3000:3000 \
-     --env-file .env \
-     -v ./uploads:/app/uploads \
-     flintsh/flare:latest
-   ```
+```bash
+version: '3.8'
 
-4. Open http://localhost:3000 to complete the setup and create your admin account.
+services:
+  db:
+    image: postgres:17-alpine
+    container_name: flare-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: flareuser
+      POSTGRES_PASSWORD: your-secure-password-here
+      POSTGRES_DB: flaredb
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U flareuser -d flaredb"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  flare:
+    image: flintsh/flare:latest
+    container_name: flare-app
+    restart: unless-stopped
+    ports:
+      - "3000:3000"                     # change left side if you want different host port
+    environment:
+      DATABASE_URL: postgresql://flareuser:your-secure-password-here@db:5432/flaredb?schema=public
+      NEXTAUTH_SECRET: securestuffhere   # generate with: openssl rand -base64 32
+      NEXTAUTH_URL: http://localhost:3000     # or https:// if using reverse proxy
+    volumes:
+      - ./uploads:/app/uploads          # where uploaded files are stored
+    depends_on:
+      db:
+        condition: service_healthy
+```
+4. Run ```docker-compose up -d```
+
+6. Open http://localhost:3000 to complete the setup and create your admin account.
 
 The official Docker image is available on Docker Hub and GitHub Container Registry as `flintsh/flare`.
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,7 @@ Click the button below to deploy Flare on Railway. Once deployed, just set your 
 
 1. Install ```docker.io``` and ```docker-compose```
 
-2. Create a `.env` file with the following required variables:
-
-   ```bash
-   DATABASE_URL=postgresql://user:pass@host:5432/dbname # (replace with your PostgreSQL connection string)
-   NEXTAUTH_SECRET=your-secure-secret-key # (generate with `openssl rand -base64 32`)
-   NEXTAUTH_URL=http://localhost:3000 # (or wherever you deploy Flare)
-   ```
-
-3. Create ```docker-compose.yml``` with the following template:
+2. Create ```docker-compose.yml``` with the following template:
 
    ```bash
    version: '3.8'
@@ -95,9 +87,9 @@ Click the button below to deploy Flare on Railway. Once deployed, just set your 
            condition: service_healthy
 
    ```
-4. Run ```docker-compose up -d```
+3. Run ```docker-compose up -d```
 
-6. Open http://localhost:3000 to complete the setup and create your admin account.
+4. Open http://localhost:3000 to complete the setup and create your admin account.
 
 The official Docker image is available on Docker Hub and GitHub Container Registry as `flintsh/flare`.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <div align="center">
   <img src="./public/banner.png" alt="Flare Banner" width="600px" />
   <p><small><i>Icon designed by <a href="https://ko-fi.com/xnefas/">xNefas</a></i></small></p>
@@ -46,13 +45,13 @@ Click the button below to deploy Flare on Railway. Once deployed, just set your 
 
 ### Docker Deployment (Self-Hosted)
 
-1. Install ```docker.io``` and ```docker-compose```
+1. Install `docker.io` and `docker-compose`
 
-2. Create ```docker-compose.yml``` with the following template:
+2. Create `docker-compose.yml` with the following template:
 
    ```bash
    version: '3.8'
-   
+
    services:
      db:
        image: postgres:17-alpine   # lightweight, recent version; 16 or 15 also fine
@@ -69,7 +68,7 @@ Click the button below to deploy Flare on Railway. Once deployed, just set your 
          interval: 10s
          timeout: 5s
          retries: 5
-   
+
      flare:
        image: flintsh/flare:latest
        container_name: flare-app
@@ -87,7 +86,8 @@ Click the button below to deploy Flare on Railway. Once deployed, just set your 
            condition: service_healthy
 
    ```
-3. Run ```docker-compose up -d```
+
+3. Run `docker-compose up -d`
 
 4. Open http://localhost:3000 to complete the setup and create your admin account.
 

--- a/README.md
+++ b/README.md
@@ -58,42 +58,43 @@ Click the button below to deploy Flare on Railway. Once deployed, just set your 
 
 3. Create ```docker-compose.yml``` with the following template:
 
-```bash
-version: '3.8'
+   ```bash
+   version: '3.8'
+   
+   services:
+     db:
+       image: postgres:17-alpine   # lightweight, recent version; 16 or 15 also fine
+       container_name: flare-db
+       restart: unless-stopped
+       environment:
+         POSTGRES_USER: flareuser          # change if you want
+         POSTGRES_PASSWORD: your-secure-password-here   #  ^f^p CHANGE THIS to something strong
+         POSTGRES_DB: flaredb              # database name Flare will use
+       volumes:
+         - ./postgres-data:/var/lib/postgresql/data   # persistent storage
+       healthcheck:
+         test: ["CMD-SHELL", "pg_isready -U flareuser -d flaredb"]
+         interval: 10s
+         timeout: 5s
+         retries: 5
+   
+     flare:
+       image: flintsh/flare:latest
+       container_name: flare-app
+       restart: unless-stopped
+       ports:
+         - "3000:3000"                     # change left side if you want different host port
+       environment:
+         DATABASE_URL: postgresql://flareuser:your-secure-password-here@db:5432/flaredb?schema=public
+         NEXTAUTH_SECRET: securestuffhere   # generate with: openssl rand -base64 32
+         NEXTAUTH_URL: http://localhost:3000     # or https:// if using reverse proxy
+       volumes:
+         - ./uploads:/app/uploads          # where files/screenshots/videos are stored
+       depends_on:
+         db:
+           condition: service_healthy
 
-services:
-  db:
-    image: postgres:17-alpine
-    container_name: flare-db
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: flareuser
-      POSTGRES_PASSWORD: your-secure-password-here
-      POSTGRES_DB: flaredb
-    volumes:
-      - ./postgres-data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U flareuser -d flaredb"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  flare:
-    image: flintsh/flare:latest
-    container_name: flare-app
-    restart: unless-stopped
-    ports:
-      - "3000:3000"                     # change left side if you want different host port
-    environment:
-      DATABASE_URL: postgresql://flareuser:your-secure-password-here@db:5432/flaredb?schema=public
-      NEXTAUTH_SECRET: securestuffhere   # generate with: openssl rand -base64 32
-      NEXTAUTH_URL: http://localhost:3000     # or https:// if using reverse proxy
-    volumes:
-      - ./uploads:/app/uploads          # where uploaded files are stored
-    depends_on:
-      db:
-        condition: service_healthy
-```
+   ```
 4. Run ```docker-compose up -d```
 
 6. Open http://localhost:3000 to complete the setup and create your admin account.


### PR DESCRIPTION
# Pull Request

## What does your PR do?
Change deployment section of README.md
Instead of
-creating and setting up a postgres database on the host 
-using a docker run command
you will have a docker-compose file that you can copy and paste, with the only (technically) required change being the nextauth key
## Why are you making these changes?
The project will be multitudes easier to deploy, as you dont need to manually install or configure the database at all.
## How did you implement it?
The postgres database is built into the docker container
## Additional Info
I do understand some people might not like the idea of containerizing the database inside of docker, whatever that may mean to you.

also, this is my first ever pull request on github, I tried!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Docker deployment guide to a docker-compose multi-service workflow instead of a single-container run.
  * Added a complete docker-compose example covering app and database services, health checks, volumes, environment variables, and port mappings.
  * Renumbered and clarified setup steps and commands to align with the new compose-based workflow; kept the final "open http://localhost:3000" instruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->