### PR TITLE
feat: Folders & Tags — organize uploads with grid/list/folder views

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Flare is a modern, self-hostable file sharing platform designed to work seamless
 - 🔒 **Secure & Private** - Role-based permissions, private files, and password protection
 - 💾 **Flexible Storage** - Local filesystem and S3-compatible storage support
 - 🖼️ **Universal Preview** - Preview images, videos, PDFs, and code with syntax highlighting
+- 🗂️ **Folders & Tags** - Optional, opt-in organization for your uploads with grid, list, and folder dashboard views, filtering, and bulk actions (stays out of your way by default)
 - 🔍 **Smart Search** - Search by filename, OCR content, and date with filters
 - 📱 **Modern UI** - Clean, responsive interface built with shadcn/ui - easily customizable
 - ⚙️ **Configurable**

--- a/__tests__/dto/organization-schemas.test.ts
+++ b/__tests__/dto/organization-schemas.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BulkFileActionSchema,
+  UpdateFileSchema,
+} from '@/types/dto/file'
+import { CreateFolderSchema, UpdateFolderSchema } from '@/types/dto/folder'
+import { CreateTagSchema } from '@/types/dto/tag'
+
+describe('CreateFolderSchema', () => {
+  it('accepts a valid folder', () => {
+    const result = CreateFolderSchema.safeParse({ name: 'Screenshots' })
+    expect(result.success).toBe(true)
+  })
+
+  it('trims the name', () => {
+    const result = CreateFolderSchema.parse({ name: '  Photos  ' })
+    expect(result.name).toBe('Photos')
+  })
+
+  it('rejects an empty name', () => {
+    expect(CreateFolderSchema.safeParse({ name: '   ' }).success).toBe(false)
+  })
+
+  it('rejects an unknown color', () => {
+    expect(
+      CreateFolderSchema.safeParse({ name: 'X', color: 'chartreuse' }).success
+    ).toBe(false)
+  })
+})
+
+describe('UpdateFolderSchema', () => {
+  it('requires at least one field', () => {
+    expect(UpdateFolderSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('allows moving to root via null parentId', () => {
+    expect(UpdateFolderSchema.safeParse({ parentId: null }).success).toBe(true)
+  })
+})
+
+describe('CreateTagSchema', () => {
+  it('accepts a valid tag', () => {
+    expect(CreateTagSchema.safeParse({ name: 'important' }).success).toBe(true)
+  })
+
+  it('rejects empty tag names', () => {
+    expect(CreateTagSchema.safeParse({ name: '' }).success).toBe(false)
+  })
+})
+
+describe('BulkFileActionSchema', () => {
+  const ids = ['ckvalidcuid000000000000001']
+
+  it('accepts a move action', () => {
+    const result = BulkFileActionSchema.safeParse({
+      fileIds: ids,
+      action: 'move',
+      folderId: null,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('requires tagIds for addTags', () => {
+    const result = BulkFileActionSchema.safeParse({
+      fileIds: ids,
+      action: 'addTags',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an empty fileIds list', () => {
+    const result = BulkFileActionSchema.safeParse({
+      fileIds: [],
+      action: 'delete',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('UpdateFileSchema', () => {
+  it('requires at least one field', () => {
+    expect(UpdateFileSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('accepts folderId null (remove from folder)', () => {
+    expect(UpdateFileSchema.safeParse({ folderId: null }).success).toBe(true)
+  })
+
+  it('accepts a tag replacement', () => {
+    expect(
+      UpdateFileSchema.safeParse({ tagIds: ['ckvalidcuid000000000000001'] })
+        .success
+    ).toBe(true)
+  })
+})

--- a/__tests__/dto/organization-schemas.test.ts
+++ b/__tests__/dto/organization-schemas.test.ts
@@ -1,11 +1,7 @@
-import { describe, expect, it } from 'vitest'
-
-import {
-  BulkFileActionSchema,
-  UpdateFileSchema,
-} from '@/types/dto/file'
+import { BulkFileActionSchema, UpdateFileSchema } from '@/types/dto/file'
 import { CreateFolderSchema, UpdateFolderSchema } from '@/types/dto/folder'
 import { CreateTagSchema } from '@/types/dto/tag'
+import { describe, expect, it } from 'vitest'
 
 describe('CreateFolderSchema', () => {
   it('accepts a valid folder', () => {

--- a/__tests__/files/query.test.ts
+++ b/__tests__/files/query.test.ts
@@ -26,7 +26,9 @@ describe('buildFileWhere', () => {
   })
 
   it('filters by mime types', () => {
-    const where = buildFileWhere('user-1', { types: ['image/png', 'image/gif'] })
+    const where = buildFileWhere('user-1', {
+      types: ['image/png', 'image/gif'],
+    })
     expect(where.AND).toContainEqual({
       mimeType: { in: ['image/png', 'image/gif'] },
     })

--- a/__tests__/files/query.test.ts
+++ b/__tests__/files/query.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildFileOrderBy, buildFileWhere } from '@/lib/files/query'
+
+describe('buildFileWhere', () => {
+  it('scopes to the user with no conditions when no filters given', () => {
+    const where = buildFileWhere('user-1', {})
+    expect(where).toEqual({ userId: 'user-1' })
+  })
+
+  it('adds a case-insensitive search across name and ocrText', () => {
+    const where = buildFileWhere('user-1', { search: 'cat' })
+    expect(where.AND).toEqual([
+      {
+        OR: [
+          { name: { contains: 'cat', mode: 'insensitive' } },
+          { ocrText: { contains: 'cat', mode: 'insensitive' } },
+        ],
+      },
+    ])
+  })
+
+  it('ignores blank/whitespace-only search', () => {
+    const where = buildFileWhere('user-1', { search: '   ' })
+    expect(where.AND).toBeUndefined()
+  })
+
+  it('filters by mime types', () => {
+    const where = buildFileWhere('user-1', { types: ['image/png', 'image/gif'] })
+    expect(where.AND).toContainEqual({
+      mimeType: { in: ['image/png', 'image/gif'] },
+    })
+  })
+
+  it('builds an inclusive end-of-day date range', () => {
+    const where = buildFileWhere('user-1', {
+      dateFrom: '2024-01-01',
+      dateTo: '2024-01-31',
+    })
+    const dateCond = (where.AND as Record<string, unknown>[]).find(
+      (c) => 'uploadedAt' in c
+    ) as { uploadedAt: { gte: Date; lte: Date } }
+    expect(dateCond.uploadedAt.gte).toEqual(new Date('2024-01-01'))
+    expect(dateCond.uploadedAt.lte.getHours()).toBe(23)
+    expect(dateCond.uploadedAt.lte.getMinutes()).toBe(59)
+  })
+
+  it('maps visibility filters including hasPassword', () => {
+    const where = buildFileWhere('user-1', {
+      visibility: ['public', 'private', 'hasPassword'],
+    })
+    expect(where.AND).toContainEqual({
+      OR: [
+        { visibility: 'PUBLIC' },
+        { visibility: 'PRIVATE' },
+        { password: { not: null } },
+      ],
+    })
+  })
+
+  it('ignores unknown visibility tokens', () => {
+    const where = buildFileWhere('user-1', { visibility: ['bogus'] })
+    expect(where.AND).toBeUndefined()
+  })
+
+  it('filters unfiled files when folderId is "none"', () => {
+    const where = buildFileWhere('user-1', { folderId: 'none' })
+    expect(where.AND).toContainEqual({ folderId: null })
+  })
+
+  it('filters by a specific folder id', () => {
+    const where = buildFileWhere('user-1', { folderId: 'folder-1' })
+    expect(where.AND).toContainEqual({ folderId: 'folder-1' })
+  })
+
+  it('does not add a folder condition for empty folderId', () => {
+    const where = buildFileWhere('user-1', { folderId: '' })
+    expect(where.AND).toBeUndefined()
+  })
+
+  it('requires every selected tag (AND semantics)', () => {
+    const where = buildFileWhere('user-1', { tags: ['t1', 't2'] })
+    expect(where.AND).toContainEqual({ tags: { some: { tagId: 't1' } } })
+    expect(where.AND).toContainEqual({ tags: { some: { tagId: 't2' } } })
+  })
+
+  it('combines multiple filters', () => {
+    const where = buildFileWhere('user-1', {
+      search: 'doc',
+      types: ['application/pdf'],
+      folderId: 'f1',
+      tags: ['t1'],
+    })
+    expect(where.userId).toBe('user-1')
+    expect((where.AND as unknown[]).length).toBe(4)
+  })
+})
+
+describe('buildFileOrderBy', () => {
+  it('defaults to newest first', () => {
+    expect(buildFileOrderBy(undefined)).toEqual({ uploadedAt: 'desc' })
+    expect(buildFileOrderBy('newest')).toEqual({ uploadedAt: 'desc' })
+  })
+
+  it('maps each known sort option', () => {
+    expect(buildFileOrderBy('oldest')).toEqual({ uploadedAt: 'asc' })
+    expect(buildFileOrderBy('largest')).toEqual({ size: 'desc' })
+    expect(buildFileOrderBy('smallest')).toEqual({ size: 'asc' })
+    expect(buildFileOrderBy('most-viewed')).toEqual({ views: 'desc' })
+    expect(buildFileOrderBy('least-viewed')).toEqual({ views: 'asc' })
+    expect(buildFileOrderBy('most-downloaded')).toEqual({ downloads: 'desc' })
+    expect(buildFileOrderBy('least-downloaded')).toEqual({ downloads: 'asc' })
+    expect(buildFileOrderBy('name-asc')).toEqual({ name: 'asc' })
+    expect(buildFileOrderBy('name')).toEqual({ name: 'asc' })
+    expect(buildFileOrderBy('name-desc')).toEqual({ name: 'desc' })
+  })
+
+  it('falls back to newest for unknown options', () => {
+    expect(buildFileOrderBy('nonsense')).toEqual({ uploadedAt: 'desc' })
+  })
+})

--- a/__tests__/folders/tree.test.ts
+++ b/__tests__/folders/tree.test.ts
@@ -1,3 +1,4 @@
+import type { FolderDTO } from '@/types/dto/folder'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -6,7 +7,6 @@ import {
   getDescendantIds,
   wouldCreateCycle,
 } from '@/lib/folders/tree'
-import type { FolderDTO } from '@/types/dto/folder'
 
 function folder(
   id: string,

--- a/__tests__/folders/tree.test.ts
+++ b/__tests__/folders/tree.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildFolderTree,
+  getBreadcrumb,
+  getDescendantIds,
+  wouldCreateCycle,
+} from '@/lib/folders/tree'
+import type { FolderDTO } from '@/types/dto/folder'
+
+function folder(
+  id: string,
+  parentId: string | null,
+  name = id,
+  fileCount = 0
+): FolderDTO {
+  return {
+    id,
+    name,
+    color: null,
+    parentId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    fileCount,
+  }
+}
+
+describe('buildFolderTree', () => {
+  it('nests children under parents and keeps roots at top', () => {
+    const tree = buildFolderTree([
+      folder('a', null, 'Alpha'),
+      folder('b', 'a', 'Bravo'),
+      folder('c', 'a', 'Charlie'),
+      folder('d', null, 'Delta'),
+    ])
+    expect(tree.map((n) => n.id)).toEqual(['a', 'd'])
+    const a = tree.find((n) => n.id === 'a')!
+    expect(a.children.map((c) => c.id)).toEqual(['b', 'c'])
+  })
+
+  it('sorts alphabetically at each level', () => {
+    const tree = buildFolderTree([
+      folder('z', null, 'Zebra'),
+      folder('a', null, 'Apple'),
+    ])
+    expect(tree.map((n) => n.name)).toEqual(['Apple', 'Zebra'])
+  })
+
+  it('aggregates descendant file counts into totalFileCount', () => {
+    const tree = buildFolderTree([
+      folder('a', null, 'A', 2),
+      folder('b', 'a', 'B', 3),
+      folder('c', 'b', 'C', 5),
+    ])
+    const a = tree[0]
+    expect(a.fileCount).toBe(2)
+    expect(a.totalFileCount).toBe(10)
+  })
+
+  it('treats folders with a missing parent as roots', () => {
+    const tree = buildFolderTree([folder('orphan', 'ghost', 'Orphan')])
+    expect(tree.map((n) => n.id)).toEqual(['orphan'])
+  })
+})
+
+describe('getDescendantIds', () => {
+  it('returns all descendants, not the node itself', () => {
+    const folders = [
+      folder('a', null),
+      folder('b', 'a'),
+      folder('c', 'b'),
+      folder('d', null),
+    ]
+    expect(getDescendantIds(folders, 'a').sort()).toEqual(['b', 'c'])
+    expect(getDescendantIds(folders, 'd')).toEqual([])
+  })
+})
+
+describe('wouldCreateCycle', () => {
+  const folders = [folder('a', null), folder('b', 'a'), folder('c', 'b')]
+
+  it('allows moving to root', () => {
+    expect(wouldCreateCycle(folders, 'b', null)).toBe(false)
+  })
+
+  it('forbids moving into itself', () => {
+    expect(wouldCreateCycle(folders, 'a', 'a')).toBe(true)
+  })
+
+  it('forbids moving into a descendant', () => {
+    expect(wouldCreateCycle(folders, 'a', 'c')).toBe(true)
+  })
+
+  it('allows moving into an unrelated folder', () => {
+    expect(wouldCreateCycle(folders, 'c', 'a')).toBe(false)
+  })
+})
+
+describe('getBreadcrumb', () => {
+  const folders = [
+    folder('a', null, 'Alpha'),
+    folder('b', 'a', 'Bravo'),
+    folder('c', 'b', 'Charlie'),
+  ]
+
+  it('builds the path from root to the folder', () => {
+    expect(getBreadcrumb(folders, 'c')).toEqual([
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Bravo' },
+      { id: 'c', name: 'Charlie' },
+    ])
+  })
+
+  it('handles a root folder', () => {
+    expect(getBreadcrumb(folders, 'a')).toEqual([{ id: 'a', name: 'Alpha' }])
+  })
+
+  it('returns empty for an unknown folder', () => {
+    expect(getBreadcrumb(folders, 'missing')).toEqual([])
+  })
+})

--- a/__tests__/tags/normalize.test.ts
+++ b/__tests__/tags/normalize.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeTagName, tagNamesEqual } from '@/lib/tags/normalize'
+import { TAG_NAME_MAX_LENGTH } from '@/types/dto/tag'
+
+describe('normalizeTagName', () => {
+  it('trims surrounding whitespace', () => {
+    expect(normalizeTagName('  design  ')).toBe('design')
+  })
+
+  it('collapses internal whitespace', () => {
+    expect(normalizeTagName('work   in     progress')).toBe('work in progress')
+  })
+
+  it('preserves casing', () => {
+    expect(normalizeTagName('ProjectX')).toBe('ProjectX')
+  })
+
+  it('clamps to the maximum length', () => {
+    const long = 'a'.repeat(TAG_NAME_MAX_LENGTH + 10)
+    expect(normalizeTagName(long).length).toBe(TAG_NAME_MAX_LENGTH)
+  })
+})
+
+describe('tagNamesEqual', () => {
+  it('is case-insensitive', () => {
+    expect(tagNamesEqual('Design', 'design')).toBe(true)
+  })
+
+  it('distinguishes different names', () => {
+    expect(tagNamesEqual('design', 'designs')).toBe(false)
+  })
+})

--- a/__tests__/tags/normalize.test.ts
+++ b/__tests__/tags/normalize.test.ts
@@ -1,7 +1,7 @@
+import { TAG_NAME_MAX_LENGTH } from '@/types/dto/tag'
 import { describe, expect, it } from 'vitest'
 
 import { normalizeTagName, tagNamesEqual } from '@/lib/tags/normalize'
-import { TAG_NAME_MAX_LENGTH } from '@/types/dto/tag'
 
 describe('normalizeTagName', () => {
   it('trims surrounding whitespace', () => {

--- a/app/(main)/dashboard/client.tsx
+++ b/app/(main)/dashboard/client.tsx
@@ -2,10 +2,14 @@
 
 import { FileGrid } from '@/components/dashboard/file-grid'
 
-export function DashboardClient() {
+interface DashboardClientProps {
+  organizationEnabled: boolean
+}
+
+export function DashboardClient({ organizationEnabled }: DashboardClientProps) {
   return (
     <div className="container space-y-6">
-      <FileGrid />
+      <FileGrid organizationEnabled={organizationEnabled} />
     </div>
   )
 }

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { getServerSession } from 'next-auth/next'
 
 import { authOptions } from '@/lib/auth'
+import { getConfig } from '@/lib/config'
 
 import { DashboardClient } from './client'
 
@@ -13,5 +14,8 @@ export default async function DashboardPage() {
     redirect('/auth/login')
   }
 
-  return <DashboardClient />
+  const config = await getConfig()
+  const organizationEnabled = config.settings.general.organization.enabled
+
+  return <DashboardClient organizationEnabled={organizationEnabled} />
 }

--- a/app/(main)/dashboard/settings/page.tsx
+++ b/app/(main)/dashboard/settings/page.tsx
@@ -1166,6 +1166,47 @@ export default function SettingsPage() {
 
               <Card>
                 <CardHeader>
+                  <CardTitle>File Organization</CardTitle>
+                  <CardDescription>
+                    Enable folders and tags so users can organize their uploads
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Enable Folders &amp; Tags</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Adds folders, tags, and extra dashboard views. When
+                        off, Flare stays a pure screenshot host and all
+                        organization UI is hidden.
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {isFieldChanged('general', [
+                        'organization',
+                        'enabled',
+                      ]) && <ChangeIndicator />}
+                      <Switch
+                        checked={
+                          workingConfig.settings.general.organization.enabled
+                        }
+                        onCheckedChange={(checked) =>
+                          handleSettingChange('general', {
+                            organization: { enabled: checked },
+                          })
+                        }
+                        className={getFieldClasses('general', [
+                          'organization',
+                          'enabled',
+                        ])}
+                      />
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
                   <CardTitle>Credits</CardTitle>
                   <CardDescription>
                     Manage footer credits visibility

--- a/app/(main)/dashboard/settings/page.tsx
+++ b/app/(main)/dashboard/settings/page.tsx
@@ -1176,9 +1176,9 @@ export default function SettingsPage() {
                     <div className="space-y-0.5">
                       <Label>Enable Folders &amp; Tags</Label>
                       <p className="text-sm text-muted-foreground">
-                        Adds folders, tags, and extra dashboard views. When
-                        off, Flare stays a pure screenshot host and all
-                        organization UI is hidden.
+                        Adds folders, tags, and extra dashboard views. When off,
+                        Flare stays a pure screenshot host and all organization
+                        UI is hidden.
                       </p>
                     </div>
                     <div className="flex items-center gap-2">

--- a/app/(main)/dashboard/upload/page.tsx
+++ b/app/(main)/dashboard/upload/page.tsx
@@ -34,6 +34,7 @@ export default async function UploadPage() {
   const maxSizeBytes =
     value * (unit === 'GB' ? 1024 * 1024 * 1024 : 1024 * 1024)
   const formattedMaxSize = formatBytes(maxSizeBytes)
+  const organizationEnabled = config.settings.general.organization.enabled
 
   return (
     <div className="container space-y-6">
@@ -54,6 +55,7 @@ export default async function UploadPage() {
             user={user}
             maxSize={maxSizeBytes}
             formattedMaxSize={formattedMaxSize}
+            organizationEnabled={organizationEnabled}
           />
         </div>
       </div>

--- a/app/api/files/[id]/route.ts
+++ b/app/api/files/[id]/route.ts
@@ -1,16 +1,15 @@
 import { NextResponse } from 'next/server'
 
+import { UpdateFileSchema } from '@/types/dto/file'
 import { Prisma } from '@prisma/client'
 import { hash } from 'bcryptjs'
 import { getServerSession } from 'next-auth'
 
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/database/prisma'
-import { isOrganizationEnabled } from '@/lib/organization'
 import { loggers } from '@/lib/logger'
+import { isOrganizationEnabled } from '@/lib/organization'
 import { getStorageProvider } from '@/lib/storage'
-
-import { UpdateFileSchema } from '@/types/dto/file'
 
 const logger = loggers.files
 
@@ -60,10 +59,7 @@ export async function PATCH(
         select: { id: true },
       })
       if (!folder) {
-        return NextResponse.json(
-          { error: 'Folder not found' },
-          { status: 404 }
-        )
+        return NextResponse.json({ error: 'Folder not found' }, { status: 404 })
       }
     }
 

--- a/app/api/files/[id]/route.ts
+++ b/app/api/files/[id]/route.ts
@@ -1,13 +1,16 @@
 import { NextResponse } from 'next/server'
 
+import { Prisma } from '@prisma/client'
 import { hash } from 'bcryptjs'
 import { getServerSession } from 'next-auth'
-import { z } from 'zod'
 
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/database/prisma'
+import { isOrganizationEnabled } from '@/lib/organization'
 import { loggers } from '@/lib/logger'
 import { getStorageProvider } from '@/lib/storage'
+
+import { UpdateFileSchema } from '@/types/dto/file'
 
 const logger = loggers.files
 
@@ -18,14 +21,10 @@ export async function PATCH(
   try {
     const { id } = await params
     const body = await request.json()
-    const schema = z.object({
-      visibility: z.enum(['PUBLIC', 'PRIVATE']).optional(),
-      password: z.string().nullable().optional(),
-    })
-    const result = schema.safeParse(body)
+    const result = UpdateFileSchema.safeParse(body)
     if (!result.success) {
       return NextResponse.json(
-        { error: 'Invalid request body' },
+        { error: result.error.issues[0]?.message || 'Invalid request body' },
         { status: 400 }
       )
     }
@@ -47,18 +46,40 @@ export async function PATCH(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const {
-      visibility,
-      password,
-    }: {
-      visibility?: 'PUBLIC' | 'PRIVATE'
-      password?: string | null
-    } = result.data
+    const { visibility, password, folderId, tagIds } = result.data
 
-    const updates: {
-      visibility?: 'PUBLIC' | 'PRIVATE'
-      password?: string | null
-    } = {}
+    const orgEnabled =
+      folderId !== undefined || tagIds !== undefined
+        ? await isOrganizationEnabled()
+        : false
+
+    // Validate folder ownership before touching anything.
+    if (orgEnabled && folderId) {
+      const folder = await prisma.folder.findFirst({
+        where: { id: folderId, userId: session.user.id },
+        select: { id: true },
+      })
+      if (!folder) {
+        return NextResponse.json(
+          { error: 'Folder not found' },
+          { status: 404 }
+        )
+      }
+    }
+
+    // Validate that any provided tags belong to the user.
+    let validTagIds: string[] = []
+    if (orgEnabled && tagIds !== undefined) {
+      if (tagIds.length > 0) {
+        const owned = await prisma.tag.findMany({
+          where: { id: { in: tagIds }, userId: session.user.id },
+          select: { id: true },
+        })
+        validTagIds = owned.map((t) => t.id)
+      }
+    }
+
+    const updates: Prisma.FileUpdateInput = {}
 
     if (visibility) {
       updates.visibility = visibility
@@ -68,9 +89,26 @@ export async function PATCH(
       updates.password = password ? await hash(password, 10) : null
     }
 
-    const updatedFile = await prisma.file.update({
-      where: { id },
-      data: updates,
+    if (orgEnabled && folderId !== undefined) {
+      updates.folder = folderId
+        ? { connect: { id: folderId } }
+        : { disconnect: true }
+    }
+
+    const updatedFile = await prisma.$transaction(async (tx) => {
+      if (orgEnabled && tagIds !== undefined) {
+        // Full replacement of the file's tags.
+        await tx.fileTag.deleteMany({ where: { fileId: id } })
+        if (validTagIds.length > 0) {
+          await tx.fileTag.createMany({
+            data: validTagIds.map((tagId) => ({ fileId: id, tagId })),
+          })
+        }
+      }
+      return tx.file.update({
+        where: { id },
+        data: updates,
+      })
     })
 
     return NextResponse.json(updatedFile)

--- a/app/api/files/bulk/route.ts
+++ b/app/api/files/bulk/route.ts
@@ -1,11 +1,11 @@
+import { BulkFileActionSchema } from '@/types/dto/file'
+
 import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
 import { requireAuth } from '@/lib/auth/api-auth'
 import { prisma } from '@/lib/database/prisma'
 import { loggers } from '@/lib/logger'
 import { isOrganizationEnabled } from '@/lib/organization'
 import { getStorageProvider } from '@/lib/storage'
-
-import { BulkFileActionSchema } from '@/types/dto/file'
 
 const logger = loggers.files
 

--- a/app/api/files/bulk/route.ts
+++ b/app/api/files/bulk/route.ts
@@ -1,0 +1,121 @@
+import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
+import { requireAuth } from '@/lib/auth/api-auth'
+import { prisma } from '@/lib/database/prisma'
+import { loggers } from '@/lib/logger'
+import { isOrganizationEnabled } from '@/lib/organization'
+import { getStorageProvider } from '@/lib/storage'
+
+import { BulkFileActionSchema } from '@/types/dto/file'
+
+const logger = loggers.files
+
+export const runtime = 'nodejs'
+
+export async function POST(req: Request) {
+  try {
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const body = await req.json()
+    const parsed = BulkFileActionSchema.safeParse(body)
+    if (!parsed.success) {
+      return apiError(
+        parsed.error.issues[0]?.message || 'Invalid request body',
+        HTTP_STATUS.BAD_REQUEST
+      )
+    }
+
+    const { fileIds, action, folderId, tagIds } = parsed.data
+
+    // Tag/folder actions require organization to be enabled. Delete is always
+    // allowed (it's a core file operation).
+    if (action !== 'delete' && !(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    // Only operate on files the user actually owns.
+    const ownedFiles = await prisma.file.findMany({
+      where: { id: { in: fileIds }, userId: user.id },
+      select: { id: true, path: true, size: true },
+    })
+    const ownedIds = ownedFiles.map((f) => f.id)
+
+    if (ownedIds.length === 0) {
+      return apiResponse({ affected: 0 })
+    }
+
+    if (action === 'move') {
+      if (folderId) {
+        const folder = await prisma.folder.findFirst({
+          where: { id: folderId, userId: user.id },
+          select: { id: true },
+        })
+        if (!folder) {
+          return apiError('Folder not found', HTTP_STATUS.NOT_FOUND)
+        }
+      }
+      await prisma.file.updateMany({
+        where: { id: { in: ownedIds } },
+        data: { folderId: folderId ?? null },
+      })
+      return apiResponse({ affected: ownedIds.length })
+    }
+
+    if (action === 'addTags') {
+      const owned = await prisma.tag.findMany({
+        where: { id: { in: tagIds ?? [] }, userId: user.id },
+        select: { id: true },
+      })
+      const validTagIds = owned.map((t) => t.id)
+      if (validTagIds.length > 0) {
+        await prisma.fileTag.createMany({
+          data: ownedIds.flatMap((fileId) =>
+            validTagIds.map((tagId) => ({ fileId, tagId }))
+          ),
+          skipDuplicates: true,
+        })
+      }
+      return apiResponse({ affected: ownedIds.length })
+    }
+
+    if (action === 'removeTags') {
+      await prisma.fileTag.deleteMany({
+        where: { fileId: { in: ownedIds }, tagId: { in: tagIds ?? [] } },
+      })
+      return apiResponse({ affected: ownedIds.length })
+    }
+
+    // action === 'delete'
+    const storageProvider = await getStorageProvider()
+    await Promise.all(
+      ownedFiles.map(async (file) => {
+        try {
+          await storageProvider.deleteFile(file.path)
+        } catch (error) {
+          logger.error('Error deleting file from storage', error as Error, {
+            fileId: file.id,
+            filePath: file.path,
+          })
+        }
+      })
+    )
+
+    const totalSizeMB = ownedFiles.reduce((sum, f) => sum + f.size, 0)
+
+    await prisma.$transaction([
+      prisma.file.deleteMany({ where: { id: { in: ownedIds } } }),
+      prisma.user.update({
+        where: { id: user.id },
+        data: { storageUsed: { decrement: totalSizeMB } },
+      }),
+    ])
+
+    return apiResponse({ affected: ownedIds.length })
+  } catch (error) {
+    logger.error('Bulk file action error', error as Error)
+    return apiError(
+      'Failed to perform bulk action',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    )
+  }
+}

--- a/app/api/files/chunks/[uploadId]/complete/route.ts
+++ b/app/api/files/chunks/[uploadId]/complete/route.ts
@@ -11,6 +11,7 @@ import { prisma } from '@/lib/database/prisma'
 import { scheduleFileExpiration } from '@/lib/events/handlers/file-expiry'
 import { loggers } from '@/lib/logger'
 import { processImageOCR } from '@/lib/ocr'
+import { resolveUploadOrganization } from '@/lib/organization/upload'
 import { validateFileType } from '@/lib/security/file-validation'
 import { validatePathSegment } from '@/lib/security/paths'
 import { getStorageProvider } from '@/lib/storage'
@@ -109,11 +110,18 @@ export async function POST(
     }
 
     const body = await req.json()
-    const { parts, expiresAt } = body
+    const { parts, expiresAt, folderId, tags } = body
 
     if (!Array.isArray(parts)) {
       return NextResponse.json({ error: 'Invalid parts data' }, { status: 400 })
     }
+
+    const { folderId: resolvedFolderId, tagIds } =
+      await resolveUploadOrganization(
+        user.id,
+        typeof folderId === 'string' ? folderId : null,
+        Array.isArray(tags) ? tags : undefined
+      )
 
     const storageProvider = await getStorageProvider()
     await storageProvider.completeMultipartUpload(
@@ -188,6 +196,12 @@ export async function POST(
               id: metadata.userId,
             },
           },
+          ...(resolvedFolderId && {
+            folder: { connect: { id: resolvedFolderId } },
+          }),
+          ...(tagIds.length > 0 && {
+            tags: { create: tagIds.map((tagId) => ({ tagId })) },
+          }),
         },
       })
 

--- a/app/api/files/route.ts
+++ b/app/api/files/route.ts
@@ -3,7 +3,6 @@ import {
   FileUploadResponse,
   FileVisibility,
 } from '@/types/dto/file'
-import { Prisma } from '@prisma/client'
 import { hash } from 'bcryptjs'
 import { join } from 'path'
 
@@ -21,9 +20,12 @@ import {
   scheduleFileExpiration,
 } from '@/lib/events/handlers/file-expiry'
 import { getUniqueFilename } from '@/lib/files/filename'
+import { buildFileOrderBy, buildFileWhere } from '@/lib/files/query'
+import { fileListSelect, serializeFile } from '@/lib/files/serialize'
 import { parseSingleFileUpload } from '@/lib/files/streaming-upload'
 import { loggers } from '@/lib/logger'
 import { processImageOCR } from '@/lib/ocr'
+import { resolveUploadOrganization } from '@/lib/organization/upload'
 import { validateFileType } from '@/lib/security/file-validation'
 import { rateLimit, uploadLimiter } from '@/lib/security/rate-limit'
 import { getStorageProvider } from '@/lib/storage'
@@ -153,6 +155,12 @@ export async function POST(req: Request) {
 
     const { displayName, urlPath, mimeType, size, urlSafeName } = upload
 
+    const { folderId, tagIds } = await resolveUploadOrganization(
+      user.id,
+      fields.folderId || null,
+      fields.tags ? fields.tags.split(',') : undefined
+    )
+
     // Validate the real file type against the claimed MIME using only the header
     // bytes read back from storage, so we never buffer the whole file in memory.
     const headStream = await storageProvider.getFileStream(filePath, {
@@ -191,6 +199,10 @@ export async function POST(req: Request) {
           visibility,
           password: password ? await hash(password, 10) : null,
           userId: user.id,
+          folderId,
+          ...(tagIds.length > 0 && {
+            tags: { create: tagIds.map((tagId) => ({ tagId })) },
+          }),
         },
       })
 
@@ -285,96 +297,21 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url)
     const page = parseInt(searchParams.get('page') || '1')
     const limit = parseInt(searchParams.get('limit') || '24')
-    const search = searchParams.get('search') || ''
     const sortBy = searchParams.get('sortBy') || 'newest'
-    const types = searchParams.get('types')?.split(',') || []
-    const dateFrom = searchParams.get('dateFrom')
-    const dateTo = searchParams.get('dateTo')
-    const visibilityFilters = searchParams.get('visibility')?.split(',') || []
     const offset = (page - 1) * limit
 
-    const where: Prisma.FileWhereInput = {
-      userId: user.id,
-    }
+    const where = buildFileWhere(user.id, {
+      search: searchParams.get('search') || '',
+      types: searchParams.get('types')?.split(',').filter(Boolean) || [],
+      dateFrom: searchParams.get('dateFrom'),
+      dateTo: searchParams.get('dateTo'),
+      visibility:
+        searchParams.get('visibility')?.split(',').filter(Boolean) || [],
+      folderId: searchParams.get('folderId') ?? undefined,
+      tags: searchParams.get('tags')?.split(',').filter(Boolean) || [],
+    })
 
-    const conditions: Prisma.FileWhereInput[] = []
-
-    if (search) {
-      conditions.push({
-        OR: [
-          { name: { contains: search, mode: 'insensitive' } },
-          { ocrText: { contains: search, mode: 'insensitive' } },
-        ],
-      })
-    }
-
-    if (types.length > 0) {
-      conditions.push({ mimeType: { in: types } })
-    }
-
-    if (dateFrom || dateTo) {
-      const dateFilter: Prisma.DateTimeFilter = {}
-      if (dateFrom) {
-        const startDate = new Date(dateFrom)
-        dateFilter.gte = startDate
-      }
-      if (dateTo) {
-        const endDate = new Date(dateTo)
-        endDate.setHours(23, 59, 59, 999)
-        dateFilter.lte = endDate
-      }
-      conditions.push({ uploadedAt: dateFilter })
-    }
-
-    if (visibilityFilters.length > 0) {
-      const visibilityConditions = []
-
-      for (const filter of visibilityFilters) {
-        if (filter === 'hasPassword') {
-          visibilityConditions.push({ password: { not: null } })
-        } else {
-          visibilityConditions.push({
-            visibility: filter.toUpperCase() as 'PUBLIC' | 'PRIVATE',
-          })
-        }
-      }
-
-      conditions.push({ OR: visibilityConditions })
-    }
-
-    if (conditions.length > 0) {
-      where.AND = conditions
-    }
-
-    const orderBy: Prisma.FileOrderByWithRelationInput = {}
-    switch (sortBy) {
-      case 'oldest':
-        orderBy.uploadedAt = 'asc'
-        break
-      case 'largest':
-        orderBy.size = 'desc'
-        break
-      case 'smallest':
-        orderBy.size = 'asc'
-        break
-      case 'most-viewed':
-        orderBy.views = 'desc'
-        break
-      case 'least-viewed':
-        orderBy.views = 'asc'
-        break
-      case 'most-downloaded':
-        orderBy.downloads = 'desc'
-        break
-      case 'least-downloaded':
-        orderBy.downloads = 'asc'
-        break
-      case 'name':
-        orderBy.name = 'asc'
-        break
-      default:
-        orderBy.uploadedAt = 'desc'
-    }
+    const orderBy = buildFileOrderBy(sortBy)
 
     const total = await prisma.file.count({ where })
 
@@ -383,35 +320,15 @@ export async function GET(request: Request) {
       orderBy,
       take: limit,
       skip: offset,
-      select: {
-        id: true,
-        name: true,
-        urlPath: true,
-        mimeType: true,
-        size: true,
-        uploadedAt: true,
-        visibility: true,
-        password: true,
-        views: true,
-        downloads: true,
-        user: {
-          select: {
-            urlId: true,
-          },
-        },
-      },
+      select: fileListSelect,
     })
 
-    const filesList = (await Promise.all(
+    const filesList: FileMetadata[] = await Promise.all(
       files.map(async (file) => {
         const expiresAt = await getFileExpirationInfo(file.id)
-        return {
-          ...file,
-          hasPassword: Boolean(file.password),
-          expiresAt,
-        }
+        return serializeFile(file, expiresAt)
       })
-    )) as (FileMetadata & { expiresAt: Date | null })[]
+    )
 
     const pagination = {
       total,

--- a/app/api/folders/[id]/route.ts
+++ b/app/api/folders/[id]/route.ts
@@ -1,3 +1,5 @@
+import { UpdateFolderSchema } from '@/types/dto/folder'
+import type { FolderDTO } from '@/types/dto/folder'
 import { Prisma } from '@prisma/client'
 
 import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
@@ -6,9 +8,6 @@ import { prisma } from '@/lib/database/prisma'
 import { getBreadcrumb, wouldCreateCycle } from '@/lib/folders/tree'
 import { loggers } from '@/lib/logger'
 import { isOrganizationEnabled } from '@/lib/organization'
-
-import { UpdateFolderSchema } from '@/types/dto/folder'
-import type { FolderDTO } from '@/types/dto/folder'
 
 const logger = loggers.files
 
@@ -117,7 +116,7 @@ export async function PATCH(
 
     const existing = await prisma.folder.findFirst({
       where: { id, userId: user.id },
-      select: { id: true },
+      select: { id: true, name: true, parentId: true },
     })
     if (!existing) {
       return apiError('Folder not found', HTTP_STATUS.NOT_FOUND)
@@ -144,6 +143,29 @@ export async function PATCH(
         return apiError(
           'Cannot move a folder into itself or one of its subfolders',
           HTTP_STATUS.BAD_REQUEST
+        )
+      }
+    }
+
+    // Enforce case-insensitive name uniqueness within the (effective) parent,
+    // since NULL parentIds bypass the DB unique constraint.
+    if (name !== undefined || parentId !== undefined) {
+      const targetName = name ?? existing.name
+      const targetParentId =
+        parentId !== undefined ? (parentId ?? null) : existing.parentId
+      const duplicate = await prisma.folder.findFirst({
+        where: {
+          userId: user.id,
+          parentId: targetParentId,
+          name: { equals: targetName, mode: 'insensitive' },
+          id: { not: id },
+        },
+        select: { id: true },
+      })
+      if (duplicate) {
+        return apiError(
+          'A folder with this name already exists here',
+          HTTP_STATUS.CONFLICT
         )
       }
     }

--- a/app/api/folders/[id]/route.ts
+++ b/app/api/folders/[id]/route.ts
@@ -1,0 +1,250 @@
+import { Prisma } from '@prisma/client'
+
+import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
+import { requireAuth } from '@/lib/auth/api-auth'
+import { prisma } from '@/lib/database/prisma'
+import { getBreadcrumb, wouldCreateCycle } from '@/lib/folders/tree'
+import { loggers } from '@/lib/logger'
+import { isOrganizationEnabled } from '@/lib/organization'
+
+import { UpdateFolderSchema } from '@/types/dto/folder'
+import type { FolderDTO } from '@/types/dto/folder'
+
+const logger = loggers.files
+
+export const runtime = 'nodejs'
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    if (!(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const { id } = await params
+
+    const folder = await prisma.folder.findFirst({
+      where: { id, userId: user.id },
+      select: {
+        id: true,
+        name: true,
+        color: true,
+        parentId: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: { select: { files: true } },
+      },
+    })
+
+    if (!folder) {
+      return apiError('Folder not found', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const allFolders = await prisma.folder.findMany({
+      where: { userId: user.id },
+      select: { id: true, name: true, parentId: true },
+    })
+
+    const children = await prisma.folder.findMany({
+      where: { userId: user.id, parentId: id },
+      select: {
+        id: true,
+        name: true,
+        color: true,
+        parentId: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: { select: { files: true } },
+      },
+      orderBy: { name: 'asc' },
+    })
+
+    const dto: FolderDTO = {
+      id: folder.id,
+      name: folder.name,
+      color: folder.color,
+      parentId: folder.parentId,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt,
+      fileCount: folder._count.files,
+    }
+
+    return apiResponse({
+      folder: dto,
+      breadcrumb: getBreadcrumb(allFolders, id),
+      children: children.map((child) => ({
+        id: child.id,
+        name: child.name,
+        color: child.color,
+        parentId: child.parentId,
+        createdAt: child.createdAt,
+        updatedAt: child.updatedAt,
+        fileCount: child._count.files,
+      })),
+    })
+  } catch (error) {
+    logger.error('Error fetching folder', error as Error)
+    return apiError('Failed to fetch folder', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    if (!(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const { id } = await params
+    const body = await req.json()
+    const parsed = UpdateFolderSchema.safeParse(body)
+    if (!parsed.success) {
+      return apiError(
+        parsed.error.issues[0]?.message || 'Invalid request body',
+        HTTP_STATUS.BAD_REQUEST
+      )
+    }
+
+    const existing = await prisma.folder.findFirst({
+      where: { id, userId: user.id },
+      select: { id: true },
+    })
+    if (!existing) {
+      return apiError('Folder not found', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { name, parentId, color } = parsed.data
+
+    if (parentId !== undefined && parentId !== null) {
+      const parent = await prisma.folder.findFirst({
+        where: { id: parentId, userId: user.id },
+        select: { id: true },
+      })
+      if (!parent) {
+        return apiError('Parent folder not found', HTTP_STATUS.NOT_FOUND)
+      }
+    }
+
+    if (parentId !== undefined) {
+      const allFolders = await prisma.folder.findMany({
+        where: { userId: user.id },
+        select: { id: true, parentId: true },
+      })
+      if (wouldCreateCycle(allFolders, id, parentId)) {
+        return apiError(
+          'Cannot move a folder into itself or one of its subfolders',
+          HTTP_STATUS.BAD_REQUEST
+        )
+      }
+    }
+
+    const data: Prisma.FolderUpdateInput = {}
+    if (name !== undefined) data.name = name
+    if (color !== undefined) data.color = color
+    if (parentId !== undefined) {
+      data.parent = parentId
+        ? { connect: { id: parentId } }
+        : { disconnect: true }
+    }
+
+    try {
+      const folder = await prisma.folder.update({
+        where: { id },
+        data,
+        select: {
+          id: true,
+          name: true,
+          color: true,
+          parentId: true,
+          createdAt: true,
+          updatedAt: true,
+          _count: { select: { files: true } },
+        },
+      })
+
+      return apiResponse<FolderDTO>({
+        id: folder.id,
+        name: folder.name,
+        color: folder.color,
+        parentId: folder.parentId,
+        createdAt: folder.createdAt,
+        updatedAt: folder.updatedAt,
+        fileCount: folder._count.files,
+      })
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        return apiError(
+          'A folder with this name already exists here',
+          HTTP_STATUS.CONFLICT
+        )
+      }
+      throw error
+    }
+  } catch (error) {
+    logger.error('Error updating folder', error as Error)
+    return apiError(
+      'Failed to update folder',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    )
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    if (!(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const { id } = await params
+
+    const folder = await prisma.folder.findFirst({
+      where: { id, userId: user.id },
+      select: { id: true, parentId: true },
+    })
+    if (!folder) {
+      return apiError('Folder not found', HTTP_STATUS.NOT_FOUND)
+    }
+
+    // Safe delete: reparent direct child folders and contained files up to this
+    // folder's parent (or root), then delete the now-empty folder. Files are
+    // never deleted by removing a folder.
+    await prisma.$transaction([
+      prisma.folder.updateMany({
+        where: { parentId: id, userId: user.id },
+        data: { parentId: folder.parentId },
+      }),
+      prisma.file.updateMany({
+        where: { folderId: id, userId: user.id },
+        data: { folderId: folder.parentId },
+      }),
+      prisma.folder.delete({ where: { id } }),
+    ])
+
+    return apiResponse({ success: true, reparentedTo: folder.parentId })
+  } catch (error) {
+    logger.error('Error deleting folder', error as Error)
+    return apiError(
+      'Failed to delete folder',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    )
+  }
+}

--- a/app/api/folders/route.ts
+++ b/app/api/folders/route.ts
@@ -1,0 +1,132 @@
+import { Prisma } from '@prisma/client'
+
+import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
+import { requireAuth } from '@/lib/auth/api-auth'
+import { prisma } from '@/lib/database/prisma'
+import { buildFolderTree } from '@/lib/folders/tree'
+import { loggers } from '@/lib/logger'
+import { isOrganizationEnabled } from '@/lib/organization'
+
+import { CreateFolderSchema } from '@/types/dto/folder'
+import type { FolderDTO } from '@/types/dto/folder'
+
+const logger = loggers.files
+
+export const runtime = 'nodejs'
+
+async function getUserFolderDTOs(userId: string): Promise<FolderDTO[]> {
+  const folders = await prisma.folder.findMany({
+    where: { userId },
+    select: {
+      id: true,
+      name: true,
+      color: true,
+      parentId: true,
+      createdAt: true,
+      updatedAt: true,
+      _count: { select: { files: true } },
+    },
+  })
+
+  return folders.map((folder) => ({
+    id: folder.id,
+    name: folder.name,
+    color: folder.color,
+    parentId: folder.parentId,
+    createdAt: folder.createdAt,
+    updatedAt: folder.updatedAt,
+    fileCount: folder._count.files,
+  }))
+}
+
+export async function GET(req: Request) {
+  try {
+    if (!(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const folders = await getUserFolderDTOs(user.id)
+    const tree = buildFolderTree(folders)
+
+    return apiResponse({ folders, tree })
+  } catch (error) {
+    logger.error('Error fetching folders', error as Error)
+    return apiError(
+      'Failed to fetch folders',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    )
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    if (!(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const body = await req.json()
+    const parsed = CreateFolderSchema.safeParse(body)
+    if (!parsed.success) {
+      return apiError(
+        parsed.error.issues[0]?.message || 'Invalid request body',
+        HTTP_STATUS.BAD_REQUEST
+      )
+    }
+
+    const { name, parentId, color } = parsed.data
+
+    if (parentId) {
+      const parent = await prisma.folder.findFirst({
+        where: { id: parentId, userId: user.id },
+        select: { id: true },
+      })
+      if (!parent) {
+        return apiError('Parent folder not found', HTTP_STATUS.NOT_FOUND)
+      }
+    }
+
+    try {
+      const folder = await prisma.folder.create({
+        data: {
+          name,
+          parentId: parentId ?? null,
+          color: color ?? null,
+          userId: user.id,
+        },
+        select: {
+          id: true,
+          name: true,
+          color: true,
+          parentId: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      })
+
+      return apiResponse<FolderDTO>({ ...folder, fileCount: 0 })
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        return apiError(
+          'A folder with this name already exists here',
+          HTTP_STATUS.CONFLICT
+        )
+      }
+      throw error
+    }
+  } catch (error) {
+    logger.error('Error creating folder', error as Error)
+    return apiError(
+      'Failed to create folder',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    )
+  }
+}

--- a/app/api/folders/route.ts
+++ b/app/api/folders/route.ts
@@ -1,3 +1,5 @@
+import { CreateFolderSchema } from '@/types/dto/folder'
+import type { FolderDTO } from '@/types/dto/folder'
 import { Prisma } from '@prisma/client'
 
 import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
@@ -6,9 +8,6 @@ import { prisma } from '@/lib/database/prisma'
 import { buildFolderTree } from '@/lib/folders/tree'
 import { loggers } from '@/lib/logger'
 import { isOrganizationEnabled } from '@/lib/organization'
-
-import { CreateFolderSchema } from '@/types/dto/folder'
-import type { FolderDTO } from '@/types/dto/folder'
 
 const logger = loggers.files
 
@@ -89,6 +88,23 @@ export async function POST(req: Request) {
       if (!parent) {
         return apiError('Parent folder not found', HTTP_STATUS.NOT_FOUND)
       }
+    }
+
+    // The DB unique constraint treats NULL parentIds as distinct, so enforce
+    // case-insensitive uniqueness within a parent (including root) ourselves.
+    const duplicate = await prisma.folder.findFirst({
+      where: {
+        userId: user.id,
+        parentId: parentId ?? null,
+        name: { equals: name, mode: 'insensitive' },
+      },
+      select: { id: true },
+    })
+    if (duplicate) {
+      return apiError(
+        'A folder with this name already exists here',
+        HTTP_STATUS.CONFLICT
+      )
     }
 
     try {

--- a/app/api/profile/export/route.ts
+++ b/app/api/profile/export/route.ts
@@ -67,9 +67,7 @@ function buildFolderPath(
   while (current && !seen.has(current.id)) {
     seen.add(current.id)
     parts.unshift(current.name.replace(/[\\/]/g, '_'))
-    current = current.parentId
-      ? foldersById.get(current.parentId)
-      : undefined
+    current = current.parentId ? foldersById.get(current.parentId) : undefined
   }
   return parts.join('/')
 }
@@ -163,6 +161,26 @@ export async function GET(req: Request) {
     const foldersById = new Map<string, FolderData>(
       userData.folders.map((f) => [f.id, f])
     )
+
+    // Guards against two files sharing a name within the same export directory.
+    const usedZipPaths = new Set<string>()
+    const uniqueZipPath = (dir: string, name: string): string => {
+      let candidate = `${dir}/${name}`
+      if (!usedZipPaths.has(candidate)) {
+        usedZipPaths.add(candidate)
+        return candidate
+      }
+      const dot = name.lastIndexOf('.')
+      const base = dot > 0 ? name.slice(0, dot) : name
+      const ext = dot > 0 ? name.slice(dot) : ''
+      let counter = 1
+      do {
+        candidate = `${dir}/${base} (${counter})${ext}`
+        counter += 1
+      } while (usedZipPaths.has(candidate))
+      usedZipPaths.add(candidate)
+      return candidate
+    }
 
     const userDataPath = join(exportDir, 'user-data.json')
     await writeFile(userDataPath, JSON.stringify(userDataForExport, null, 2))
@@ -270,7 +288,7 @@ export async function GET(req: Request) {
               const baseDir = folderPath
                 ? `files/${folderPath}`
                 : `files/${new Date(file.uploadedAt).toISOString().split('T')[0]}`
-              const zipPath = `${baseDir}/${safeName}`
+              const zipPath = uniqueZipPath(baseDir, safeName)
               try {
                 archive.file(filePath, { name: zipPath })
                 successfulFiles++

--- a/app/api/profile/export/route.ts
+++ b/app/api/profile/export/route.ts
@@ -25,6 +25,8 @@ type FileData = {
   ocrText: string | null
   isPaste: boolean
   path: string
+  folderId: string | null
+  tags: { tag: { name: string } }[]
 }
 
 type ShortenedUrlData = {
@@ -34,6 +36,12 @@ type ShortenedUrlData = {
   createdAt: Date
 }
 
+type FolderData = {
+  id: string
+  name: string
+  parentId: string | null
+}
+
 type UserData = {
   id: string
   name: string | null
@@ -41,7 +49,29 @@ type UserData = {
   createdAt: Date
   updatedAt: Date
   files: FileData[]
+  folders: FolderData[]
+  tags: { name: string; color: string | null }[]
   shortenedUrls: ShortenedUrlData[]
+}
+
+// Builds a filesystem-safe folder path (e.g. "Screenshots/2024") for a file's
+// folder by walking up the parent chain.
+function buildFolderPath(
+  folderId: string | null,
+  foldersById: Map<string, FolderData>
+): string {
+  if (!folderId) return ''
+  const parts: string[] = []
+  const seen = new Set<string>()
+  let current = foldersById.get(folderId)
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id)
+    parts.unshift(current.name.replace(/[\\/]/g, '_'))
+    current = current.parentId
+      ? foldersById.get(current.parentId)
+      : undefined
+  }
+  return parts.join('/')
 }
 
 export const dynamic = 'force-dynamic'
@@ -93,7 +123,15 @@ export async function GET(req: Request) {
             ocrText: true,
             isPaste: true,
             path: true,
+            folderId: true,
+            tags: { select: { tag: { select: { name: true } } } },
           },
+        },
+        folders: {
+          select: { id: true, name: true, parentId: true },
+        },
+        tags: {
+          select: { name: true, color: true },
         },
         shortenedUrls: {
           select: {
@@ -117,8 +155,14 @@ export async function GET(req: Request) {
       createdAt: userData.createdAt,
       updatedAt: userData.updatedAt,
       files: userData.files,
+      folders: userData.folders,
+      tags: userData.tags,
       shortenedUrls: userData.shortenedUrls,
     }
+
+    const foldersById = new Map<string, FolderData>(
+      userData.folders.map((f) => [f.id, f])
+    )
 
     const userDataPath = join(exportDir, 'user-data.json')
     await writeFile(userDataPath, JSON.stringify(userDataForExport, null, 2))
@@ -222,7 +266,11 @@ export async function GET(req: Request) {
 
             if (filePath) {
               const safeName = sanitizeDisplayName(file.name)
-              const zipPath = `files/${new Date(file.uploadedAt).toISOString().split('T')[0]}/${safeName}`
+              const folderPath = buildFolderPath(file.folderId, foldersById)
+              const baseDir = folderPath
+                ? `files/${folderPath}`
+                : `files/${new Date(file.uploadedAt).toISOString().split('T')[0]}`
+              const zipPath = `${baseDir}/${safeName}`
               try {
                 archive.file(filePath, { name: zipPath })
                 successfulFiles++

--- a/app/api/setup/route.ts
+++ b/app/api/setup/route.ts
@@ -121,6 +121,9 @@ export async function POST(req: Request) {
           ocr: {
             enabled: true,
           },
+          organization: {
+            enabled: true,
+          },
         },
         appearance: {
           theme: 'dark',

--- a/app/api/tags/[id]/route.ts
+++ b/app/api/tags/[id]/route.ts
@@ -1,3 +1,5 @@
+import { UpdateTagSchema } from '@/types/dto/tag'
+import type { TagDTO } from '@/types/dto/tag'
 import { Prisma } from '@prisma/client'
 
 import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
@@ -6,9 +8,6 @@ import { prisma } from '@/lib/database/prisma'
 import { loggers } from '@/lib/logger'
 import { isOrganizationEnabled } from '@/lib/organization'
 import { normalizeTagName } from '@/lib/tags/normalize'
-
-import { UpdateTagSchema } from '@/types/dto/tag'
-import type { TagDTO } from '@/types/dto/tag'
 
 const logger = loggers.files
 
@@ -80,7 +79,10 @@ export async function PATCH(
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2002'
       ) {
-        return apiError('A tag with this name already exists', HTTP_STATUS.CONFLICT)
+        return apiError(
+          'A tag with this name already exists',
+          HTTP_STATUS.CONFLICT
+        )
       }
       throw error
     }

--- a/app/api/tags/[id]/route.ts
+++ b/app/api/tags/[id]/route.ts
@@ -1,0 +1,123 @@
+import { Prisma } from '@prisma/client'
+
+import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
+import { requireAuth } from '@/lib/auth/api-auth'
+import { prisma } from '@/lib/database/prisma'
+import { loggers } from '@/lib/logger'
+import { isOrganizationEnabled } from '@/lib/organization'
+import { normalizeTagName } from '@/lib/tags/normalize'
+
+import { UpdateTagSchema } from '@/types/dto/tag'
+import type { TagDTO } from '@/types/dto/tag'
+
+const logger = loggers.files
+
+export const runtime = 'nodejs'
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    if (!(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const { id } = await params
+    const body = await req.json()
+    const parsed = UpdateTagSchema.safeParse(body)
+    if (!parsed.success) {
+      return apiError(
+        parsed.error.issues[0]?.message || 'Invalid request body',
+        HTTP_STATUS.BAD_REQUEST
+      )
+    }
+
+    const existing = await prisma.tag.findFirst({
+      where: { id, userId: user.id },
+      select: { id: true },
+    })
+    if (!existing) {
+      return apiError('Tag not found', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const data: Prisma.TagUpdateInput = {}
+    if (parsed.data.name !== undefined) {
+      const name = normalizeTagName(parsed.data.name)
+      if (!name) {
+        return apiError('Tag name is required', HTTP_STATUS.BAD_REQUEST)
+      }
+      data.name = name
+    }
+    if (parsed.data.color !== undefined) {
+      data.color = parsed.data.color
+    }
+
+    try {
+      const tag = await prisma.tag.update({
+        where: { id },
+        data,
+        select: {
+          id: true,
+          name: true,
+          color: true,
+          createdAt: true,
+          _count: { select: { files: true } },
+        },
+      })
+      return apiResponse<TagDTO>({
+        id: tag.id,
+        name: tag.name,
+        color: tag.color,
+        createdAt: tag.createdAt,
+        fileCount: tag._count.files,
+      })
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        return apiError('A tag with this name already exists', HTTP_STATUS.CONFLICT)
+      }
+      throw error
+    }
+  } catch (error) {
+    logger.error('Error updating tag', error as Error)
+    return apiError('Failed to update tag', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    if (!(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const { id } = await params
+
+    const existing = await prisma.tag.findFirst({
+      where: { id, userId: user.id },
+      select: { id: true },
+    })
+    if (!existing) {
+      return apiError('Tag not found', HTTP_STATUS.NOT_FOUND)
+    }
+
+    // FileTag rows cascade away; the files themselves are untouched.
+    await prisma.tag.delete({ where: { id } })
+
+    return apiResponse({ success: true })
+  } catch (error) {
+    logger.error('Error deleting tag', error as Error)
+    return apiError('Failed to delete tag', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,3 +1,5 @@
+import { CreateTagSchema } from '@/types/dto/tag'
+import type { TagDTO } from '@/types/dto/tag'
 import { Prisma } from '@prisma/client'
 
 import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
@@ -6,9 +8,6 @@ import { prisma } from '@/lib/database/prisma'
 import { loggers } from '@/lib/logger'
 import { isOrganizationEnabled } from '@/lib/organization'
 import { normalizeTagName } from '@/lib/tags/normalize'
-
-import { CreateTagSchema } from '@/types/dto/tag'
-import type { TagDTO } from '@/types/dto/tag'
 
 const logger = loggers.files
 
@@ -112,7 +111,10 @@ export async function POST(req: Request) {
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2002'
       ) {
-        return apiError('A tag with this name already exists', HTTP_STATUS.CONFLICT)
+        return apiError(
+          'A tag with this name already exists',
+          HTTP_STATUS.CONFLICT
+        )
       }
       throw error
     }

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,0 +1,123 @@
+import { Prisma } from '@prisma/client'
+
+import { HTTP_STATUS, apiError, apiResponse } from '@/lib/api/response'
+import { requireAuth } from '@/lib/auth/api-auth'
+import { prisma } from '@/lib/database/prisma'
+import { loggers } from '@/lib/logger'
+import { isOrganizationEnabled } from '@/lib/organization'
+import { normalizeTagName } from '@/lib/tags/normalize'
+
+import { CreateTagSchema } from '@/types/dto/tag'
+import type { TagDTO } from '@/types/dto/tag'
+
+const logger = loggers.files
+
+export const runtime = 'nodejs'
+
+export async function GET(req: Request) {
+  try {
+    if (!(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const tags = await prisma.tag.findMany({
+      where: { userId: user.id },
+      select: {
+        id: true,
+        name: true,
+        color: true,
+        createdAt: true,
+        _count: { select: { files: true } },
+      },
+      orderBy: { name: 'asc' },
+    })
+
+    const dtos: TagDTO[] = tags.map((tag) => ({
+      id: tag.id,
+      name: tag.name,
+      color: tag.color,
+      createdAt: tag.createdAt,
+      fileCount: tag._count.files,
+    }))
+
+    return apiResponse({ tags: dtos })
+  } catch (error) {
+    logger.error('Error fetching tags', error as Error)
+    return apiError('Failed to fetch tags', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    if (!(await isOrganizationEnabled())) {
+      return apiError('Organization is disabled', HTTP_STATUS.NOT_FOUND)
+    }
+
+    const { user, response } = await requireAuth(req)
+    if (response) return response
+
+    const body = await req.json()
+    const parsed = CreateTagSchema.safeParse(body)
+    if (!parsed.success) {
+      return apiError(
+        parsed.error.issues[0]?.message || 'Invalid request body',
+        HTTP_STATUS.BAD_REQUEST
+      )
+    }
+
+    const name = normalizeTagName(parsed.data.name)
+    if (!name) {
+      return apiError('Tag name is required', HTTP_STATUS.BAD_REQUEST)
+    }
+
+    // Case-insensitive duplicate detection so "Design" and "design" don't both
+    // exist for the same user.
+    const existing = await prisma.tag.findFirst({
+      where: { userId: user.id, name: { equals: name, mode: 'insensitive' } },
+      select: {
+        id: true,
+        name: true,
+        color: true,
+        createdAt: true,
+        _count: { select: { files: true } },
+      },
+    })
+    if (existing) {
+      // Idempotent create: return the existing tag so "create on the fly" flows
+      // never error on a tag the user already has.
+      return apiResponse<TagDTO>({
+        id: existing.id,
+        name: existing.name,
+        color: existing.color,
+        createdAt: existing.createdAt,
+        fileCount: existing._count.files,
+      })
+    }
+
+    try {
+      const tag = await prisma.tag.create({
+        data: {
+          name,
+          color: parsed.data.color ?? null,
+          userId: user.id,
+        },
+        select: { id: true, name: true, color: true, createdAt: true },
+      })
+      return apiResponse<TagDTO>({ ...tag, fileCount: 0 })
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        return apiError('A tag with this name already exists', HTTP_STATUS.CONFLICT)
+      }
+      throw error
+    }
+  } catch (error) {
+    logger.error('Error creating tag', error as Error)
+    return apiError('Failed to create tag', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}

--- a/components/dashboard/bulk-actions-bar.tsx
+++ b/components/dashboard/bulk-actions-bar.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { Download, FolderInput, Tag as TagIcon, Trash2, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+import { TagPicker } from '@/components/dashboard/tag/tag-picker'
+
+import type { Tag } from '@/types/components/tag'
+
+interface BulkActionsBarProps {
+  count: number
+  tags: Tag[]
+  onClear: () => void
+  onMove: () => void
+  onAddTags: (tagIds: string[]) => void
+  onCreateTag: (name: string) => Promise<Tag | null>
+  onDownload: () => void
+  onDelete: () => void
+}
+
+export function BulkActionsBar({
+  count,
+  tags,
+  onClear,
+  onMove,
+  onAddTags,
+  onCreateTag,
+  onDownload,
+  onDelete,
+}: BulkActionsBarProps) {
+  if (count === 0) return null
+
+  return (
+    <div className="fixed bottom-8 left-0 right-0 flex justify-center z-50 px-4 pointer-events-none">
+      <div className="pointer-events-auto flex items-center gap-2 px-3 py-2 bg-background/90 backdrop-blur-md border rounded-full shadow-lg">
+        <div className="flex items-center gap-2 pl-1 pr-2">
+          <span className="flex items-center justify-center min-w-6 h-6 px-1.5 rounded-full bg-primary text-primary-foreground text-xs font-semibold">
+            {count}
+          </span>
+          <span className="text-sm font-medium hidden sm:inline">selected</span>
+        </div>
+
+        <div className="h-5 w-px bg-border" />
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onMove}
+          className="rounded-full gap-1.5"
+        >
+          <FolderInput className="h-4 w-4" />
+          <span className="hidden sm:inline">Move</span>
+        </Button>
+
+        <TagPicker
+          tags={tags}
+          selectedIds={[]}
+          onToggle={(tagId) => onAddTags([tagId])}
+          onCreate={onCreateTag}
+          align="center"
+          trigger={
+            <Button variant="ghost" size="sm" className="rounded-full gap-1.5">
+              <TagIcon className="h-4 w-4" />
+              <span className="hidden sm:inline">Tag</span>
+            </Button>
+          }
+        />
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDownload}
+          className="rounded-full gap-1.5"
+        >
+          <Download className="h-4 w-4" />
+          <span className="hidden sm:inline">Download</span>
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDelete}
+          className="rounded-full gap-1.5 text-destructive hover:text-destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+          <span className="hidden sm:inline">Delete</span>
+        </Button>
+
+        <div className="h-5 w-px bg-border" />
+
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClear}
+          className="rounded-full h-8 w-8"
+          aria-label="Clear selection"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/bulk-actions-bar.tsx
+++ b/components/dashboard/bulk-actions-bar.tsx
@@ -1,12 +1,10 @@
 'use client'
 
+import type { Tag } from '@/types/components/tag'
 import { Download, FolderInput, Tag as TagIcon, Trash2, X } from 'lucide-react'
 
-import { Button } from '@/components/ui/button'
-
 import { TagPicker } from '@/components/dashboard/tag/tag-picker'
-
-import type { Tag } from '@/types/components/tag'
+import { Button } from '@/components/ui/button'
 
 interface BulkActionsBarProps {
   count: number

--- a/components/dashboard/file-card/index.tsx
+++ b/components/dashboard/file-card/index.tsx
@@ -288,9 +288,7 @@ export function FileCard({
             <div className="rounded-md bg-background/80 backdrop-blur-sm p-1 shadow-sm">
               <Checkbox
                 checked={selected}
-                onCheckedChange={(value) =>
-                  onSelectChange?.(file.id, value)
-                }
+                onCheckedChange={(value) => onSelectChange?.(file.id, value)}
                 aria-label={selected ? 'Deselect file' : 'Select file'}
               />
             </div>

--- a/components/dashboard/file-card/index.tsx
+++ b/components/dashboard/file-card/index.tsx
@@ -13,21 +13,26 @@ import {
   Download,
   Eye,
   EyeOff,
+  Folder as FolderIcon,
+  FolderInput,
   Globe,
   KeyRound,
   Link as LinkIcon,
   Lock,
   ScanText,
+  Tags,
   Timer,
   Trash2,
 } from 'lucide-react'
 
 import { getFileIcon } from '@/components/dashboard/file-card/utils'
+import { TagBadge } from '@/components/dashboard/tag/tag-badge'
 import { ExpiryModal } from '@/components/shared/expiry-modal'
 import { Icons } from '@/components/shared/icons'
 import { OcrDialog } from '@/components/shared/ocr-dialog'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -52,9 +57,26 @@ import { useToast } from '@/hooks/use-toast'
 interface FileCardProps {
   file: FileType
   onDelete?: (id: string) => void
+  organizationEnabled?: boolean
+  selectable?: boolean
+  selected?: boolean
+  onSelectChange?: (id: string, selected: boolean) => void
+  onRequestMove?: (file: FileType) => void
+  onRequestEditTags?: (file: FileType) => void
+  onTagClick?: (tagId: string) => void
 }
 
-export function FileCard({ file: initialFile, onDelete }: FileCardProps) {
+export function FileCard({
+  file: initialFile,
+  onDelete,
+  organizationEnabled = false,
+  selectable = false,
+  selected = false,
+  onSelectChange,
+  onRequestMove,
+  onRequestEditTags,
+  onTagClick,
+}: FileCardProps) {
   const { toast } = useToast()
   const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false)
   const [isVisibilityDialogOpen, setIsVisibilityDialogOpen] = useState(false)
@@ -250,9 +272,30 @@ export function FileCard({ file: initialFile, onDelete }: FileCardProps) {
   const isImage = file.mimeType.startsWith('image/')
 
   return (
-    <Card className="group relative overflow-hidden bg-background/40 backdrop-blur-xl border-border/50 shadow-lg shadow-black/5 hover:shadow-xl hover:shadow-black/10 transition-all duration-300 hover:bg-background/60">
+    <Card
+      className={`group relative overflow-hidden bg-background/40 backdrop-blur-xl border-border/50 shadow-lg shadow-black/5 hover:shadow-xl hover:shadow-black/10 transition-all duration-300 hover:bg-background/60 ${
+        selected ? 'ring-2 ring-primary border-primary/60' : ''
+      }`}
+    >
       {}
       <div className="relative">
+        {selectable && (
+          <div
+            className={`absolute top-2 left-2 z-10 transition-opacity ${
+              selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+            }`}
+          >
+            <div className="rounded-md bg-background/80 backdrop-blur-sm p-1 shadow-sm">
+              <Checkbox
+                checked={selected}
+                onCheckedChange={(value) =>
+                  onSelectChange?.(file.id, value)
+                }
+                aria-label={selected ? 'Deselect file' : 'Select file'}
+              />
+            </div>
+          </div>
+        )}
         <Link href={sanitizeUrl(file.urlPath)} className="block">
           {isImage ? (
             <div className="relative aspect-square">
@@ -355,6 +398,36 @@ export function FileCard({ file: initialFile, onDelete }: FileCardProps) {
                 </TooltipTrigger>
                 <TooltipContent>Password protect</TooltipContent>
               </Tooltip>
+              {organizationEnabled && onRequestMove && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="secondary"
+                      size="icon"
+                      className="h-8 w-8 glass-hover"
+                      onClick={() => onRequestMove(initialFile)}
+                    >
+                      <FolderInput className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Move to folder</TooltipContent>
+                </Tooltip>
+              )}
+              {organizationEnabled && onRequestEditTags && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="secondary"
+                      size="icon"
+                      className="h-8 w-8 glass-hover"
+                      onClick={() => onRequestEditTags(initialFile)}
+                    >
+                      <Tags className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Edit tags</TooltipContent>
+                </Tooltip>
+              )}
               {isImage && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -515,7 +588,30 @@ export function FileCard({ file: initialFile, onDelete }: FileCardProps) {
             <Download className="mr-1 h-3 w-3" />
             {file.downloads}
           </div>
+          {organizationEnabled && initialFile.folder && (
+            <div className="flex items-center min-w-0">
+              <FolderIcon className="mr-1 h-3 w-3 shrink-0" />
+              <span className="truncate">{initialFile.folder.name}</span>
+            </div>
+          )}
         </div>
+        {organizationEnabled && initialFile.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {initialFile.tags.slice(0, 3).map((tag) => (
+              <TagBadge
+                key={tag.id}
+                name={tag.name}
+                color={tag.color}
+                onClick={onTagClick ? () => onTagClick(tag.id) : undefined}
+              />
+            ))}
+            {initialFile.tags.length > 3 && (
+              <span className="text-xs text-muted-foreground self-center">
+                +{initialFile.tags.length - 3}
+              </span>
+            )}
+          </div>
+        )}
       </div>
 
       {}

--- a/components/dashboard/file-grid/index.tsx
+++ b/components/dashboard/file-grid/index.tsx
@@ -21,13 +21,13 @@ import {
 } from '@/components/dashboard/file-grid/pagination'
 import { SearchInput } from '@/components/dashboard/file-grid/search-input'
 import { ViewSwitcher } from '@/components/dashboard/file-grid/view-switcher'
+import { EditTagsDialog } from '@/components/dashboard/file/edit-tags-dialog'
 import { FolderBreadcrumb } from '@/components/dashboard/folder/folder-breadcrumb'
 import { FolderCard } from '@/components/dashboard/folder/folder-card'
 import { FolderDialog } from '@/components/dashboard/folder/folder-dialog'
 import { FolderFilter } from '@/components/dashboard/folder/folder-filter'
 import { FolderSidebar } from '@/components/dashboard/folder/folder-sidebar'
 import { MoveToFolderDialog } from '@/components/dashboard/folder/move-to-folder-dialog'
-import { EditTagsDialog } from '@/components/dashboard/file/edit-tags-dialog'
 import { ManageTagsDialog } from '@/components/dashboard/tag/manage-tags-dialog'
 import { TagFilter } from '@/components/dashboard/tag/tag-filter'
 import { EmptyPlaceholder } from '@/components/shared/empty-placeholder'
@@ -42,7 +42,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 
-import { getDescendantIds, getBreadcrumb } from '@/lib/folders/tree'
+import { getBreadcrumb, getDescendantIds } from '@/lib/folders/tree'
 
 import { useFileFilters } from '@/hooks/use-file-filters'
 import { useFileSelection } from '@/hooks/use-file-selection'
@@ -54,10 +54,7 @@ interface FileGridProps {
   organizationEnabled?: boolean
 }
 
-function findNode(
-  nodes: FolderTreeNode[],
-  id: string
-): FolderTreeNode | null {
+function findNode(nodes: FolderTreeNode[], id: string): FolderTreeNode | null {
   for (const node of nodes) {
     if (node.id === id) return node
     const found = findNode(node.children, id)
@@ -434,9 +431,7 @@ export function FileGrid({ organizationEnabled = false }: FileGridProps) {
       onRequestEditTags={(f) => setEditTagsFile(f)}
       onTagClick={(tagId) =>
         setTags(
-          filters.tags.includes(tagId)
-            ? filters.tags
-            : [...filters.tags, tagId]
+          filters.tags.includes(tagId) ? filters.tags : [...filters.tags, tagId]
         )
       }
       onDelete={handleDelete}

--- a/components/dashboard/file-grid/index.tsx
+++ b/components/dashboard/file-grid/index.tsx
@@ -1,25 +1,73 @@
-import { useCallback, useEffect, useState } from 'react'
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import type {
   FileType,
   PaginationInfo,
   SortOption,
 } from '@/types/components/file'
+import type { FolderTreeNode } from '@/types/components/folder'
 import type { DateRange } from 'react-day-picker'
 
+import { BulkActionsBar } from '@/components/dashboard/bulk-actions-bar'
 import { FileCard } from '@/components/dashboard/file-card'
 import { FileCardSkeleton } from '@/components/dashboard/file-grid/file-card-skeleton'
 import { FileFilters } from '@/components/dashboard/file-grid/file-filters'
+import { FileListView } from '@/components/dashboard/file-grid/list-view'
 import {
   FileGridPagination,
   PaginationSkeleton,
 } from '@/components/dashboard/file-grid/pagination'
 import { SearchInput } from '@/components/dashboard/file-grid/search-input'
+import { ViewSwitcher } from '@/components/dashboard/file-grid/view-switcher'
+import { FolderBreadcrumb } from '@/components/dashboard/folder/folder-breadcrumb'
+import { FolderCard } from '@/components/dashboard/folder/folder-card'
+import { FolderDialog } from '@/components/dashboard/folder/folder-dialog'
+import { FolderFilter } from '@/components/dashboard/folder/folder-filter'
+import { FolderSidebar } from '@/components/dashboard/folder/folder-sidebar'
+import { MoveToFolderDialog } from '@/components/dashboard/folder/move-to-folder-dialog'
+import { EditTagsDialog } from '@/components/dashboard/file/edit-tags-dialog'
+import { ManageTagsDialog } from '@/components/dashboard/tag/manage-tags-dialog'
+import { TagFilter } from '@/components/dashboard/tag/tag-filter'
 import { EmptyPlaceholder } from '@/components/shared/empty-placeholder'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+import { getDescendantIds, getBreadcrumb } from '@/lib/folders/tree'
 
 import { useFileFilters } from '@/hooks/use-file-filters'
+import { useFileSelection } from '@/hooks/use-file-selection'
+import { useFolders } from '@/hooks/use-folders'
+import { useTags } from '@/hooks/use-tags'
+import { useToast } from '@/hooks/use-toast'
 
-export function FileGrid() {
+interface FileGridProps {
+  organizationEnabled?: boolean
+}
+
+function findNode(
+  nodes: FolderTreeNode[],
+  id: string
+): FolderTreeNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node
+    const found = findNode(node.children, id)
+    if (found) return found
+  }
+  return null
+}
+
+export function FileGrid({ organizationEnabled = false }: FileGridProps) {
+  const { toast } = useToast()
   const [files, setFiles] = useState<FileType[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [fileTypes, setFileTypes] = useState<string[]>([])
@@ -38,7 +86,47 @@ export function FileGrid() {
     setVisibility,
     setSortBy,
     setPage,
+    setFolderId,
+    setTags,
+    setViewMode,
   } = useFileFilters()
+
+  const {
+    folders,
+    tree,
+    createFolder,
+    updateFolder,
+    deleteFolder,
+    refetch: refetchFolders,
+  } = useFolders({ enabled: organizationEnabled })
+  const {
+    tags,
+    createTag,
+    updateTag,
+    deleteTag,
+    refetch: refetchTags,
+  } = useTags({ enabled: organizationEnabled })
+
+  const selection = useFileSelection()
+
+  // Dialog state.
+  const [createParentId, setCreateParentId] = useState<
+    string | null | undefined
+  >(undefined)
+  const [renameTarget, setRenameTarget] = useState<FolderTreeNode | null>(null)
+  const [moveFolderTarget, setMoveFolderTarget] =
+    useState<FolderTreeNode | null>(null)
+  const [moveFileIds, setMoveFileIds] = useState<string[] | null>(null)
+  const [editTagsFile, setEditTagsFile] = useState<FileType | null>(null)
+  const [manageTagsOpen, setManageTagsOpen] = useState(false)
+  const [deleteFolderTarget, setDeleteFolderTarget] =
+    useState<FolderTreeNode | null>(null)
+
+  const isFolderView = filters.viewMode === 'folder' && organizationEnabled
+  const currentFolderId =
+    isFolderView && filters.folderId && filters.folderId !== 'none'
+      ? filters.folderId
+      : null
 
   const handleDateChange = useCallback(
     (range: DateRange | undefined) => {
@@ -59,77 +147,198 @@ export function FileGrid() {
       try {
         const response = await fetch('/api/files/types')
         if (!response.ok) {
-          console.error('Failed to fetch file types, status:', response.status)
           setFileTypes([])
           return
         }
         const data = await response.json()
         setFileTypes(Array.isArray(data.data.types) ? data.data.types : [])
-      } catch (error) {
-        console.error('Error fetching file types:', error)
+      } catch {
         setFileTypes([])
       }
     }
     fetchFileTypes()
   }, [])
 
-  useEffect(() => {
-    async function fetchFiles() {
-      try {
-        setIsLoading(true)
-        const params = new URLSearchParams({
-          page: filters.page.toString(),
-          limit: filters.limit.toString(),
-          search: filters.search,
-          sortBy: filters.sortBy,
-          ...(filters.types.length > 0 && { types: filters.types.join(',') }),
-          ...(filters.dateFrom && { dateFrom: filters.dateFrom }),
-          ...(filters.dateTo && { dateTo: filters.dateTo }),
-          ...(filters.visibility.length > 0 && {
-            visibility: filters.visibility.join(','),
-          }),
-        })
-        const response = await fetch(`/api/files?${params}`)
-        if (!response.ok) throw new Error('Failed to fetch files')
-        const apiResult = await response.json()
-        console.log(
-          'API Response for /api/files:',
-          JSON.stringify(apiResult, null, 2)
-        )
-        setFiles(Array.isArray(apiResult.data) ? apiResult.data : [])
-        if (apiResult.pagination) {
-          setPaginationInfo({
-            total: apiResult.pagination.total || 0,
-            pageCount: apiResult.pagination.pageCount || 0,
-            page: filters.page,
-            limit: filters.limit,
-          })
-        } else {
-          setPaginationInfo({
-            total: 0,
-            pageCount: 0,
-            page: filters.page,
-            limit: filters.limit,
-          })
-        }
-      } catch (error) {
-        console.error('Error fetching files:', error)
-      } finally {
-        setIsLoading(false)
-      }
+  const typesKey = filters.types.join(',')
+  const tagsKey = filters.tags.join(',')
+  const visibilityKey = filters.visibility.join(',')
+
+  const fetchFiles = useCallback(async () => {
+    try {
+      setIsLoading(true)
+
+      // In folder view, the file list shows the current folder's direct files
+      // (unfiled at the root). Elsewhere the folder filter is applied verbatim.
+      const folderParam = isFolderView
+        ? (currentFolderId ?? 'none')
+        : filters.folderId || ''
+
+      const params = new URLSearchParams({
+        page: filters.page.toString(),
+        limit: filters.limit.toString(),
+        search: filters.search,
+        sortBy: filters.sortBy,
+        ...(typesKey && { types: typesKey }),
+        ...(filters.dateFrom && { dateFrom: filters.dateFrom }),
+        ...(filters.dateTo && { dateTo: filters.dateTo }),
+        ...(visibilityKey && { visibility: visibilityKey }),
+        ...(folderParam && { folderId: folderParam }),
+        ...(tagsKey && { tags: tagsKey }),
+      })
+      const response = await fetch(`/api/files?${params}`)
+      if (!response.ok) throw new Error('Failed to fetch files')
+      const apiResult = await response.json()
+      setFiles(Array.isArray(apiResult.data) ? apiResult.data : [])
+      setPaginationInfo({
+        total: apiResult.pagination?.total || 0,
+        pageCount: apiResult.pagination?.pageCount || 0,
+        page: filters.page,
+        limit: filters.limit,
+      })
+    } catch (error) {
+      console.error('Error fetching files:', error)
+    } finally {
+      setIsLoading(false)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    filters.page,
+    filters.limit,
+    filters.search,
+    filters.sortBy,
+    filters.dateFrom,
+    filters.dateTo,
+    filters.folderId,
+    filters.viewMode,
+    typesKey,
+    tagsKey,
+    visibilityKey,
+    isFolderView,
+    currentFolderId,
+  ])
 
+  useEffect(() => {
     fetchFiles()
-  }, [filters])
+  }, [fetchFiles])
 
-  const handleDelete = (fileId: string) => {
-    setFiles((files) => files.filter((file) => file.id !== fileId))
-    setPaginationInfo((prev) => ({
-      ...prev,
-      total: prev.total - 1,
-      pageCount: Math.ceil((prev.total - 1) / prev.limit),
-    }))
-  }
+  const refreshAfterMutation = useCallback(async () => {
+    await fetchFiles()
+    if (organizationEnabled) {
+      await Promise.all([refetchFolders(), refetchTags()])
+    }
+  }, [fetchFiles, organizationEnabled, refetchFolders, refetchTags])
+
+  const handleDelete = useCallback(
+    (fileId: string) => {
+      setFiles((prev) => prev.filter((file) => file.id !== fileId))
+      setPaginationInfo((prev) => ({
+        ...prev,
+        total: Math.max(0, prev.total - 1),
+        pageCount: Math.ceil(Math.max(0, prev.total - 1) / prev.limit),
+      }))
+      selection.deselect(fileId)
+    },
+    [selection]
+  )
+
+  const handleSelectAll = useCallback(
+    (selected: boolean) => {
+      if (selected) {
+        selection.selectMany(files.map((f) => f.id))
+      } else {
+        selection.clear()
+      }
+    },
+    [files, selection]
+  )
+
+  // Bulk actions.
+  const bulkAction = useCallback(
+    async (body: Record<string, unknown>) => {
+      const response = await fetch('/api/files/bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        toast({ title: 'Action failed', variant: 'destructive' })
+        return false
+      }
+      return true
+    },
+    [toast]
+  )
+
+  const handleBulkAddTags = useCallback(
+    async (tagIds: string[]) => {
+      const ok = await bulkAction({
+        fileIds: selection.selectedArray,
+        action: 'addTags',
+        tagIds,
+      })
+      if (ok) {
+        toast({ title: 'Tags added' })
+        await refreshAfterMutation()
+      }
+    },
+    [bulkAction, refreshAfterMutation, selection.selectedArray, toast]
+  )
+
+  const handleBulkDownload = useCallback(() => {
+    for (const id of selection.selectedArray) {
+      const a = document.createElement('a')
+      a.href = `/api/files/${id}/download`
+      a.download = ''
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+    }
+  }, [selection.selectedArray])
+
+  const handleBulkDelete = useCallback(async () => {
+    const ok = await bulkAction({
+      fileIds: selection.selectedArray,
+      action: 'delete',
+    })
+    if (ok) {
+      toast({ title: 'Files deleted' })
+      selection.clear()
+      await refreshAfterMutation()
+    }
+  }, [bulkAction, refreshAfterMutation, selection, toast])
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
+
+  // Folder card children for folder view.
+  const folderChildren: FolderTreeNode[] = useMemo(() => {
+    if (!isFolderView) return []
+    if (!currentFolderId) return tree
+    return findNode(tree, currentFolderId)?.children ?? []
+  }, [isFolderView, currentFolderId, tree])
+
+  const breadcrumb = useMemo(
+    () =>
+      currentFolderId
+        ? getBreadcrumb(
+            folders.map((f) => ({
+              id: f.id,
+              name: f.name,
+              parentId: f.parentId,
+            })),
+            currentFolderId
+          )
+        : [],
+    [folders, currentFolderId]
+  )
+
+  // Disabled destinations when moving a folder (itself + descendants).
+  const moveFolderDisabledIds = useMemo(() => {
+    if (!moveFolderTarget) return new Set<string>()
+    const ids = getDescendantIds(
+      folders.map((f) => ({ id: f.id, parentId: f.parentId })),
+      moveFolderTarget.id
+    )
+    return new Set<string>([moveFolderTarget.id, ...ids])
+  }, [moveFolderTarget, folders])
 
   const dateRangeValue =
     filters.dateFrom || filters.dateTo
@@ -139,13 +348,136 @@ export function FileGrid() {
         }
       : undefined
 
+  const hasActiveFilters = Boolean(
+    filters.search ||
+      filters.types.length > 0 ||
+      filters.visibility.length > 0 ||
+      filters.dateFrom ||
+      filters.dateTo ||
+      filters.tags.length > 0 ||
+      (filters.folderId && !isFolderView)
+  )
+
+  const handleMoveConfirm = useCallback(
+    async (folderId: string | null) => {
+      if (!moveFileIds) return
+      const ok = await bulkAction({
+        fileIds: moveFileIds,
+        action: 'move',
+        folderId,
+      })
+      if (ok) {
+        toast({ title: 'Moved' })
+        selection.clear()
+        await refreshAfterMutation()
+      }
+      setMoveFileIds(null)
+    },
+    [moveFileIds, bulkAction, toast, selection, refreshAfterMutation]
+  )
+
+  const handleEditTagsSave = useCallback(
+    async (tagIds: string[]) => {
+      if (!editTagsFile) return
+      const response = await fetch(`/api/files/${editTagsFile.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tagIds }),
+      })
+      if (!response.ok) {
+        toast({ title: 'Failed to update tags', variant: 'destructive' })
+        return false
+      }
+      toast({ title: 'Tags updated' })
+      await refreshAfterMutation()
+    },
+    [editTagsFile, toast, refreshAfterMutation]
+  )
+
+  const renderFileGrid = () => (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {files.map((file) => (
+        <FileCard
+          key={file.id}
+          file={file}
+          onDelete={handleDelete}
+          organizationEnabled={organizationEnabled}
+          selectable={organizationEnabled}
+          selected={selection.isSelected(file.id)}
+          onSelectChange={(id, sel) =>
+            sel ? selection.select(id) : selection.deselect(id)
+          }
+          onRequestMove={(f) => setMoveFileIds([f.id])}
+          onRequestEditTags={(f) => setEditTagsFile(f)}
+          onTagClick={(tagId) =>
+            setTags(
+              filters.tags.includes(tagId)
+                ? filters.tags
+                : [...filters.tags, tagId]
+            )
+          }
+        />
+      ))}
+    </div>
+  )
+
+  const renderFileList = () => (
+    <FileListView
+      files={files}
+      organizationEnabled={organizationEnabled}
+      selectedIds={selection.selectedIds}
+      onSelectChange={(id, sel) =>
+        sel ? selection.select(id) : selection.deselect(id)
+      }
+      onSelectAll={handleSelectAll}
+      onRequestMove={(f) => setMoveFileIds([f.id])}
+      onRequestEditTags={(f) => setEditTagsFile(f)}
+      onTagClick={(tagId) =>
+        setTags(
+          filters.tags.includes(tagId)
+            ? filters.tags
+            : [...filters.tags, tagId]
+        )
+      }
+      onDelete={handleDelete}
+    />
+  )
+
+  const renderEmpty = () => (
+    <EmptyPlaceholder>
+      <EmptyPlaceholder.Icon name="file" />
+      {hasActiveFilters ? (
+        <>
+          <EmptyPlaceholder.Title>No files found</EmptyPlaceholder.Title>
+          <EmptyPlaceholder.Description>
+            Try adjusting your filters to find files.
+          </EmptyPlaceholder.Description>
+        </>
+      ) : isFolderView && currentFolderId ? (
+        <>
+          <EmptyPlaceholder.Title>This folder is empty</EmptyPlaceholder.Title>
+          <EmptyPlaceholder.Description>
+            Upload files here or move existing files into this folder.
+          </EmptyPlaceholder.Description>
+        </>
+      ) : (
+        <>
+          <EmptyPlaceholder.Title>No files uploaded</EmptyPlaceholder.Title>
+          <EmptyPlaceholder.Description>
+            Upload your first file to get started.
+          </EmptyPlaceholder.Description>
+        </>
+      )}
+    </EmptyPlaceholder>
+  )
+
   const renderContent = () => {
     if (isLoading) {
       return (
         <>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {Array.from({ length: 24 }, (_, i) => (
-              <FileCardSkeleton key={`skeleton-${Date.now()}-${i}`} />
+            {Array.from({ length: 12 }, (_, i) => (
+              <FileCardSkeleton key={`skeleton-${i}`} />
             ))}
           </div>
           <PaginationSkeleton />
@@ -153,43 +485,30 @@ export function FileGrid() {
       )
     }
 
-    if (files.length === 0 && paginationInfo.total === 0) {
-      const hasActiveFilters =
-        filters.search ||
-        filters.types.length > 0 ||
-        filters.visibility.length > 0 ||
-        filters.dateFrom ||
-        filters.dateTo
+    const showFolderCards = isFolderView && folderChildren.length > 0
+    const noFiles = files.length === 0 && paginationInfo.total === 0
 
-      return (
-        <EmptyPlaceholder>
-          <EmptyPlaceholder.Icon name="file" />
-          {hasActiveFilters ? (
-            <>
-              <EmptyPlaceholder.Title>No files found</EmptyPlaceholder.Title>
-              <EmptyPlaceholder.Description>
-                Try adjusting your filters to find files.
-              </EmptyPlaceholder.Description>
-            </>
-          ) : (
-            <>
-              <EmptyPlaceholder.Title>No files uploaded</EmptyPlaceholder.Title>
-              <EmptyPlaceholder.Description>
-                Upload your first file to get started.
-              </EmptyPlaceholder.Description>
-            </>
-          )}
-        </EmptyPlaceholder>
-      )
+    if (noFiles && !showFolderCards) {
+      return renderEmpty()
     }
 
     return (
       <>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {files.map((file) => (
-            <FileCard key={file.id} file={file} onDelete={handleDelete} />
-          ))}
-        </div>
+        {showFolderCards && (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 mb-6">
+            {folderChildren.map((node) => (
+              <FolderCard
+                key={node.id}
+                folder={node}
+                onOpen={(id) => setFolderId(id)}
+                onRename={(f) => setRenameTarget(f)}
+                onMove={(f) => setMoveFolderTarget(f)}
+                onDelete={(f) => setDeleteFolderTarget(f)}
+              />
+            ))}
+          </div>
+        )}
+        {filters.viewMode === 'list' ? renderFileList() : renderFileGrid()}
         <FileGridPagination paginationInfo={paginationInfo} setPage={setPage} />
       </>
     )
@@ -197,38 +516,242 @@ export function FileGrid() {
 
   return (
     <div className="space-y-6">
-      {}
       <div className="relative rounded-2xl bg-white/10 dark:bg-black/10 backdrop-blur-xl border border-white/20 dark:border-white/10 shadow-lg shadow-black/5 dark:shadow-black/20">
         <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-white/10 via-transparent to-black/5 dark:from-white/5 dark:via-transparent dark:to-black/10" />
         <div className="relative">
-          {}
-          <div className="p-6 pb-4">
-            <h1 className="text-3xl font-bold">Your Files</h1>
-            <p className="text-muted-foreground mt-1">
-              View and manage your uploaded files
-            </p>
+          <div className="p-6 pb-4 flex items-start justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold">Your Files</h1>
+              <p className="text-muted-foreground mt-1">
+                View and manage your uploaded files
+              </p>
+            </div>
+            <ViewSwitcher
+              value={filters.viewMode}
+              onChange={setViewMode}
+              allowFolder={organizationEnabled}
+            />
           </div>
 
-          {}
           <div className="px-6 pb-6">
-            <div className="flex flex-col sm:flex-row gap-4">
+            <div className="flex flex-col sm:flex-row gap-4 flex-wrap">
               <SearchInput onSearch={setSearch} initialValue={filters.search} />
-              <FileFilters
-                sortBy={filters.sortBy as SortOption}
-                onSortChange={setSortBy}
-                selectedTypes={filters.types}
-                onTypesChange={setTypes}
-                fileTypes={fileTypes}
-                date={dateRangeValue}
-                onDateChange={handleDateChange}
-                visibility={filters.visibility}
-                onVisibilityChange={setVisibility}
-              />
+              <div className="flex gap-2 flex-wrap">
+                {organizationEnabled && !isFolderView && (
+                  <FolderFilter
+                    tree={tree}
+                    value={filters.folderId}
+                    onChange={setFolderId}
+                  />
+                )}
+                {organizationEnabled && (
+                  <TagFilter
+                    tags={tags}
+                    selectedIds={filters.tags}
+                    onChange={setTags}
+                    onManage={() => setManageTagsOpen(true)}
+                  />
+                )}
+                <FileFilters
+                  sortBy={filters.sortBy as SortOption}
+                  onSortChange={setSortBy}
+                  selectedTypes={filters.types}
+                  onTypesChange={setTypes}
+                  fileTypes={fileTypes}
+                  date={dateRangeValue}
+                  onDateChange={handleDateChange}
+                  visibility={filters.visibility}
+                  onVisibilityChange={setVisibility}
+                />
+              </div>
             </div>
           </div>
         </div>
       </div>
-      {renderContent()}
+
+      {isFolderView ? (
+        <div className="flex flex-col lg:flex-row gap-6">
+          <aside className="lg:w-64 shrink-0">
+            <div className="rounded-2xl bg-background/40 backdrop-blur-xl border border-border/50 p-3 lg:sticky lg:top-24">
+              <FolderSidebar
+                tree={tree}
+                totalFileCount={0}
+                selectedFolderId={filters.folderId}
+                onSelect={setFolderId}
+                onCreateRoot={() => setCreateParentId(null)}
+                onCreateChild={(parentId) => setCreateParentId(parentId)}
+                onRename={(node) => setRenameTarget(node)}
+                onMove={(node) => setMoveFolderTarget(node)}
+                onDelete={(node) => setDeleteFolderTarget(node)}
+              />
+            </div>
+          </aside>
+          <div className="flex-1 min-w-0 space-y-4">
+            {currentFolderId && (
+              <FolderBreadcrumb items={breadcrumb} onNavigate={setFolderId} />
+            )}
+            {renderContent()}
+          </div>
+        </div>
+      ) : (
+        renderContent()
+      )}
+
+      {organizationEnabled && (
+        <BulkActionsBar
+          count={selection.count}
+          tags={tags}
+          onClear={selection.clear}
+          onMove={() => setMoveFileIds(selection.selectedArray)}
+          onAddTags={handleBulkAddTags}
+          onCreateTag={(name) => createTag({ name })}
+          onDownload={handleBulkDownload}
+          onDelete={() => setBulkDeleteOpen(true)}
+        />
+      )}
+
+      {/* Folder create/rename dialog */}
+      <FolderDialog
+        open={createParentId !== undefined}
+        onOpenChange={(open) => !open && setCreateParentId(undefined)}
+        mode="create"
+        onSubmit={async ({ name, color }) => {
+          const created = await createFolder({
+            name,
+            parentId: createParentId ?? null,
+            color,
+          })
+          return created !== null
+        }}
+      />
+      <FolderDialog
+        open={renameTarget !== null}
+        onOpenChange={(open) => !open && setRenameTarget(null)}
+        mode="rename"
+        initialName={renameTarget?.name}
+        initialColor={renameTarget?.color}
+        onSubmit={async ({ name, color }) => {
+          if (!renameTarget) return false
+          return updateFolder(renameTarget.id, { name, color })
+        }}
+      />
+
+      {/* Move a folder */}
+      <MoveToFolderDialog
+        open={moveFolderTarget !== null}
+        onOpenChange={(open) => !open && setMoveFolderTarget(null)}
+        tree={tree}
+        disabledIds={moveFolderDisabledIds}
+        title={`Move "${moveFolderTarget?.name ?? ''}"`}
+        onSelect={async (folderId) => {
+          if (!moveFolderTarget) return false
+          return updateFolder(moveFolderTarget.id, { parentId: folderId })
+        }}
+      />
+
+      {/* Move file(s) */}
+      <MoveToFolderDialog
+        open={moveFileIds !== null}
+        onOpenChange={(open) => !open && setMoveFileIds(null)}
+        tree={tree}
+        title={
+          moveFileIds && moveFileIds.length > 1
+            ? `Move ${moveFileIds.length} files`
+            : 'Move file'
+        }
+        onSelect={handleMoveConfirm}
+      />
+
+      {/* Edit a single file's tags */}
+      {editTagsFile && (
+        <EditTagsDialog
+          open={editTagsFile !== null}
+          onOpenChange={(open) => !open && setEditTagsFile(null)}
+          fileName={editTagsFile.name}
+          allTags={tags}
+          initialTagIds={editTagsFile.tags.map((t) => t.id)}
+          onCreateTag={(name) => createTag({ name })}
+          onSave={handleEditTagsSave}
+        />
+      )}
+
+      {/* Manage tags */}
+      <ManageTagsDialog
+        open={manageTagsOpen}
+        onOpenChange={setManageTagsOpen}
+        tags={tags}
+        onCreate={(input) => createTag(input)}
+        onUpdate={(id, input) => updateTag(id, input)}
+        onDelete={async (id) => {
+          const ok = await deleteTag(id)
+          if (ok) {
+            setTags(filters.tags.filter((t) => t !== id))
+            await fetchFiles()
+          }
+          return ok
+        }}
+      />
+
+      {/* Delete folder confirmation */}
+      <AlertDialog
+        open={deleteFolderTarget !== null}
+        onOpenChange={(open) => !open && setDeleteFolderTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete &ldquo;{deleteFolderTarget?.name}&rdquo;?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              The files inside this folder will be kept and moved up one level.
+              Any subfolders will also move up. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                if (!deleteFolderTarget) return
+                const ok = await deleteFolder(deleteFolderTarget.id)
+                if (ok) {
+                  if (filters.folderId === deleteFolderTarget.id) {
+                    setFolderId(null)
+                  }
+                  await fetchFiles()
+                }
+                setDeleteFolderTarget(null)
+              }}
+            >
+              Delete folder
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Bulk delete confirmation */}
+      <AlertDialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {selection.count} file{selection.count === 1 ? '' : 's'}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              These files will be permanently deleted. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                setBulkDeleteOpen(false)
+                await handleBulkDelete()
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/components/dashboard/file-grid/list-view.tsx
+++ b/components/dashboard/file-grid/list-view.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 
+import type { FileType } from '@/types/components/file'
 import { format } from 'date-fns'
 import {
   Download,
@@ -38,8 +39,6 @@ import { sanitizeUrl } from '@/lib/utils/url'
 
 import { useToast } from '@/hooks/use-toast'
 
-import type { FileType } from '@/types/components/file'
-
 interface FileListViewProps {
   files: FileType[]
   organizationEnabled?: boolean
@@ -64,7 +63,8 @@ export function FileListView({
   onDelete,
 }: FileListViewProps) {
   const { toast } = useToast()
-  const allSelected = files.length > 0 && files.every((f) => selectedIds.has(f.id))
+  const allSelected =
+    files.length > 0 && files.every((f) => selectedIds.has(f.id))
 
   const handleCopyLink = (file: FileType) => {
     navigator.clipboard.writeText(
@@ -203,7 +203,9 @@ export function FileListView({
                   <TableCell className="hidden md:table-cell text-sm text-muted-foreground whitespace-nowrap">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span>{getRelativeTime(new Date(file.uploadedAt))}</span>
+                        <span>
+                          {getRelativeTime(new Date(file.uploadedAt))}
+                        </span>
                       </TooltipTrigger>
                       <TooltipContent>
                         {format(new Date(file.uploadedAt), 'PPP p')}

--- a/components/dashboard/file-grid/list-view.tsx
+++ b/components/dashboard/file-grid/list-view.tsx
@@ -1,0 +1,299 @@
+'use client'
+
+import Link from 'next/link'
+
+import { format } from 'date-fns'
+import {
+  Download,
+  FolderInput,
+  Globe,
+  KeyRound,
+  Link as LinkIcon,
+  Lock,
+  Tags,
+  Trash2,
+} from 'lucide-react'
+
+import { getFileIcon } from '@/components/dashboard/file-card/utils'
+import { TagBadge } from '@/components/dashboard/tag/tag-badge'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+import { formatFileSize, getRelativeTime } from '@/lib/utils'
+import { sanitizeUrl } from '@/lib/utils/url'
+
+import { useToast } from '@/hooks/use-toast'
+
+import type { FileType } from '@/types/components/file'
+
+interface FileListViewProps {
+  files: FileType[]
+  organizationEnabled?: boolean
+  selectedIds: Set<string>
+  onSelectChange: (id: string, selected: boolean) => void
+  onSelectAll: (selected: boolean) => void
+  onRequestMove: (file: FileType) => void
+  onRequestEditTags: (file: FileType) => void
+  onTagClick: (tagId: string) => void
+  onDelete: (id: string) => void
+}
+
+export function FileListView({
+  files,
+  organizationEnabled = false,
+  selectedIds,
+  onSelectChange,
+  onSelectAll,
+  onRequestMove,
+  onRequestEditTags,
+  onTagClick,
+  onDelete,
+}: FileListViewProps) {
+  const { toast } = useToast()
+  const allSelected = files.length > 0 && files.every((f) => selectedIds.has(f.id))
+
+  const handleCopyLink = (file: FileType) => {
+    navigator.clipboard.writeText(
+      `${window.location.origin}${sanitizeUrl(file.urlPath)}`
+    )
+    toast({
+      title: 'Link copied',
+      description: 'File link has been copied to clipboard',
+    })
+  }
+
+  const handleDelete = async (file: FileType) => {
+    try {
+      const response = await fetch(`/api/files/${file.id}`, {
+        method: 'DELETE',
+      })
+      if (!response.ok) throw new Error()
+      onDelete(file.id)
+      toast({
+        title: 'File deleted',
+        description: 'The file has been permanently deleted',
+      })
+    } catch {
+      toast({
+        title: 'Failed to delete file',
+        description: 'Please try again',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-border/50 bg-background/40 backdrop-blur-xl overflow-hidden">
+      <TooltipProvider delayDuration={150}>
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="w-10">
+                <Checkbox
+                  checked={allSelected}
+                  onCheckedChange={onSelectAll}
+                  aria-label="Select all files"
+                />
+              </TableHead>
+              <TableHead>Name</TableHead>
+              {organizationEnabled && (
+                <TableHead className="hidden lg:table-cell">Folder</TableHead>
+              )}
+              {organizationEnabled && (
+                <TableHead className="hidden xl:table-cell">Tags</TableHead>
+              )}
+              <TableHead className="hidden md:table-cell">Size</TableHead>
+              <TableHead className="hidden sm:table-cell">Visibility</TableHead>
+              <TableHead className="hidden lg:table-cell text-right">
+                Views
+              </TableHead>
+              <TableHead className="hidden md:table-cell">Uploaded</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {files.map((file) => {
+              const selected = selectedIds.has(file.id)
+              return (
+                <TableRow
+                  key={file.id}
+                  className={selected ? 'bg-accent/40' : undefined}
+                >
+                  <TableCell>
+                    <Checkbox
+                      checked={selected}
+                      onCheckedChange={(value) =>
+                        onSelectChange(file.id, value)
+                      }
+                      aria-label="Select file"
+                    />
+                  </TableCell>
+                  <TableCell className="max-w-[260px]">
+                    <Link
+                      href={sanitizeUrl(file.urlPath)}
+                      className="flex items-center gap-2 hover:underline"
+                    >
+                      <span className="text-muted-foreground shrink-0">
+                        {getFileIcon(file.mimeType, 'h-4 w-4')}
+                      </span>
+                      <span className="truncate font-medium text-sm">
+                        {file.name}
+                      </span>
+                    </Link>
+                  </TableCell>
+                  {organizationEnabled && (
+                    <TableCell className="hidden lg:table-cell text-sm text-muted-foreground">
+                      {file.folder?.name ?? '—'}
+                    </TableCell>
+                  )}
+                  {organizationEnabled && (
+                    <TableCell className="hidden xl:table-cell">
+                      <div className="flex flex-wrap gap-1 max-w-[200px]">
+                        {file.tags.slice(0, 2).map((tag) => (
+                          <TagBadge
+                            key={tag.id}
+                            name={tag.name}
+                            color={tag.color}
+                            onClick={() => onTagClick(tag.id)}
+                          />
+                        ))}
+                        {file.tags.length > 2 && (
+                          <span className="text-xs text-muted-foreground self-center">
+                            +{file.tags.length - 2}
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                  )}
+                  <TableCell className="hidden md:table-cell text-sm text-muted-foreground whitespace-nowrap">
+                    {formatFileSize(file.size)}
+                  </TableCell>
+                  <TableCell className="hidden sm:table-cell">
+                    {file.password ? (
+                      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <KeyRound className="h-3 w-3" /> Protected
+                      </span>
+                    ) : file.visibility === 'PUBLIC' ? (
+                      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <Globe className="h-3 w-3" /> Public
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <Lock className="h-3 w-3" /> Private
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell className="hidden lg:table-cell text-right text-sm text-muted-foreground">
+                    {file.views}
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell text-sm text-muted-foreground whitespace-nowrap">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span>{getRelativeTime(new Date(file.uploadedAt))}</span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {format(new Date(file.uploadedAt), 'PPP p')}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center justify-end gap-1">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={() => handleCopyLink(file)}
+                          >
+                            <LinkIcon className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Copy link</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            asChild
+                          >
+                            <a
+                              href={`/api/files/${file.id}/download`}
+                              download={file.name}
+                            >
+                              <Download className="h-4 w-4" />
+                            </a>
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Download</TooltipContent>
+                      </Tooltip>
+                      {organizationEnabled && (
+                        <>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8"
+                                onClick={() => onRequestMove(file)}
+                              >
+                                <FolderInput className="h-4 w-4" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>Move to folder</TooltipContent>
+                          </Tooltip>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8"
+                                onClick={() => onRequestEditTags(file)}
+                              >
+                                <Tags className="h-4 w-4" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>Edit tags</TooltipContent>
+                          </Tooltip>
+                        </>
+                      )}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-destructive hover:text-destructive"
+                            onClick={() => handleDelete(file)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Delete</TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </TooltipProvider>
+    </div>
+  )
+}

--- a/components/dashboard/file-grid/view-switcher.tsx
+++ b/components/dashboard/file-grid/view-switcher.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { ViewMode } from '@/types/components/file'
 import { FolderTree, LayoutGrid, List } from 'lucide-react'
 
 import {
@@ -10,8 +11,6 @@ import {
 } from '@/components/ui/tooltip'
 
 import { cn } from '@/lib/utils'
-
-import type { ViewMode } from '@/types/components/file'
 
 interface ViewSwitcherProps {
   value: ViewMode

--- a/components/dashboard/file-grid/view-switcher.tsx
+++ b/components/dashboard/file-grid/view-switcher.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { FolderTree, LayoutGrid, List } from 'lucide-react'
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+import { cn } from '@/lib/utils'
+
+import type { ViewMode } from '@/types/components/file'
+
+interface ViewSwitcherProps {
+  value: ViewMode
+  onChange: (mode: ViewMode) => void
+  allowFolder?: boolean
+}
+
+const OPTIONS: { mode: ViewMode; icon: React.ElementType; label: string }[] = [
+  { mode: 'grid', icon: LayoutGrid, label: 'Grid' },
+  { mode: 'list', icon: List, label: 'List' },
+  { mode: 'folder', icon: FolderTree, label: 'Folders' },
+]
+
+export function ViewSwitcher({
+  value,
+  onChange,
+  allowFolder = true,
+}: ViewSwitcherProps) {
+  const options = allowFolder
+    ? OPTIONS
+    : OPTIONS.filter((o) => o.mode !== 'folder')
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div className="inline-flex items-center rounded-lg border border-border/50 bg-background/60 backdrop-blur-sm p-0.5">
+        {options.map(({ mode, icon: Icon, label }) => (
+          <Tooltip key={mode}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => onChange(mode)}
+                aria-label={`${label} view`}
+                aria-pressed={value === mode}
+                className={cn(
+                  'flex h-8 w-9 items-center justify-center rounded-md transition-all duration-200',
+                  value === mode
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                <Icon className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/components/dashboard/file/edit-tags-dialog.tsx
+++ b/components/dashboard/file/edit-tags-dialog.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Plus } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+import { TagBadge } from '@/components/dashboard/tag/tag-badge'
+import { TagPicker } from '@/components/dashboard/tag/tag-picker'
+
+import type { Tag } from '@/types/components/tag'
+
+interface EditTagsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  fileName: string
+  allTags: Tag[]
+  initialTagIds: string[]
+  onCreateTag: (name: string) => Promise<Tag | null>
+  onSave: (tagIds: string[]) => Promise<boolean | void> | void
+}
+
+export function EditTagsDialog({
+  open,
+  onOpenChange,
+  fileName,
+  allTags,
+  initialTagIds,
+  onCreateTag,
+  onSave,
+}: EditTagsDialogProps) {
+  const [selected, setSelected] = useState<string[]>(initialTagIds)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (open) setSelected(initialTagIds)
+  }, [open, initialTagIds])
+
+  const toggle = (tagId: string) => {
+    setSelected((prev) =>
+      prev.includes(tagId)
+        ? prev.filter((t) => t !== tagId)
+        : [...prev, tagId]
+    )
+  }
+
+  const selectedTags = allTags.filter((t) => selected.includes(t.id))
+
+  const handleSave = async () => {
+    setSaving(true)
+    const result = await onSave(selected)
+    setSaving(false)
+    if (result !== false) onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="truncate">Tags for {fileName}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="flex flex-wrap gap-1.5 min-h-8">
+            {selectedTags.length === 0 && (
+              <span className="text-sm text-muted-foreground">
+                No tags assigned
+              </span>
+            )}
+            {selectedTags.map((tag) => (
+              <TagBadge
+                key={tag.id}
+                name={tag.name}
+                color={tag.color}
+                onRemove={() => toggle(tag.id)}
+              />
+            ))}
+          </div>
+          <TagPicker
+            tags={allTags}
+            selectedIds={selected}
+            onToggle={toggle}
+            onCreate={onCreateTag}
+            trigger={
+              <Button variant="outline" size="sm" className="gap-1.5">
+                <Plus className="h-4 w-4" />
+                Add tags
+              </Button>
+            }
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              Save
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/dashboard/file/edit-tags-dialog.tsx
+++ b/components/dashboard/file/edit-tags-dialog.tsx
@@ -2,8 +2,11 @@
 
 import { useEffect, useState } from 'react'
 
+import type { Tag } from '@/types/components/tag'
 import { Plus } from 'lucide-react'
 
+import { TagBadge } from '@/components/dashboard/tag/tag-badge'
+import { TagPicker } from '@/components/dashboard/tag/tag-picker'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -11,11 +14,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-
-import { TagBadge } from '@/components/dashboard/tag/tag-badge'
-import { TagPicker } from '@/components/dashboard/tag/tag-picker'
-
-import type { Tag } from '@/types/components/tag'
 
 interface EditTagsDialogProps {
   open: boolean
@@ -45,9 +43,7 @@ export function EditTagsDialog({
 
   const toggle = (tagId: string) => {
     setSelected((prev) =>
-      prev.includes(tagId)
-        ? prev.filter((t) => t !== tagId)
-        : [...prev, tagId]
+      prev.includes(tagId) ? prev.filter((t) => t !== tagId) : [...prev, tagId]
     )
   }
 

--- a/components/dashboard/folder/color-picker.tsx
+++ b/components/dashboard/folder/color-picker.tsx
@@ -19,7 +19,8 @@ export function ColorPicker({ value, onChange }: ColorPickerProps) {
         onClick={() => onChange(null)}
         className={cn(
           'h-6 w-6 rounded-full border border-border bg-muted-foreground/30 flex items-center justify-center',
-          value === null && 'ring-2 ring-ring ring-offset-2 ring-offset-background'
+          value === null &&
+            'ring-2 ring-ring ring-offset-2 ring-offset-background'
         )}
         aria-label="No color"
       >

--- a/components/dashboard/folder/color-picker.tsx
+++ b/components/dashboard/folder/color-picker.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { Check } from 'lucide-react'
+
+import { ORGANIZATION_COLORS, getColorClasses } from '@/lib/organization/colors'
+import type { OrganizationColor } from '@/lib/organization/colors'
+import { cn } from '@/lib/utils'
+
+interface ColorPickerProps {
+  value: OrganizationColor | null
+  onChange: (color: OrganizationColor | null) => void
+}
+
+export function ColorPicker({ value, onChange }: ColorPickerProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={() => onChange(null)}
+        className={cn(
+          'h-6 w-6 rounded-full border border-border bg-muted-foreground/30 flex items-center justify-center',
+          value === null && 'ring-2 ring-ring ring-offset-2 ring-offset-background'
+        )}
+        aria-label="No color"
+      >
+        {value === null && <Check className="h-3 w-3 text-foreground" />}
+      </button>
+      {ORGANIZATION_COLORS.map((color) => {
+        const classes = getColorClasses(color)
+        return (
+          <button
+            key={color}
+            type="button"
+            onClick={() => onChange(color)}
+            className={cn(
+              'h-6 w-6 rounded-full flex items-center justify-center transition-transform hover:scale-110',
+              classes.dot,
+              value === color &&
+                'ring-2 ring-ring ring-offset-2 ring-offset-background'
+            )}
+            aria-label={color}
+          >
+            {value === color && <Check className="h-3 w-3 text-white" />}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/dashboard/folder/folder-breadcrumb.tsx
+++ b/components/dashboard/folder/folder-breadcrumb.tsx
@@ -1,10 +1,9 @@
 'use client'
 
+import type { FolderBreadcrumbItem } from '@/types/components/folder'
 import { ChevronRight, Home } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
-
-import type { FolderBreadcrumbItem } from '@/types/components/folder'
 
 interface FolderBreadcrumbProps {
   items: FolderBreadcrumbItem[]

--- a/components/dashboard/folder/folder-breadcrumb.tsx
+++ b/components/dashboard/folder/folder-breadcrumb.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { ChevronRight, Home } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+import type { FolderBreadcrumbItem } from '@/types/components/folder'
+
+interface FolderBreadcrumbProps {
+  items: FolderBreadcrumbItem[]
+  onNavigate: (folderId: string | null) => void
+}
+
+export function FolderBreadcrumb({ items, onNavigate }: FolderBreadcrumbProps) {
+  return (
+    <nav className="flex items-center gap-1 text-sm flex-wrap">
+      <button
+        type="button"
+        onClick={() => onNavigate(null)}
+        className="flex items-center gap-1 rounded-md px-2 py-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+      >
+        <Home className="h-3.5 w-3.5" />
+        <span>All files</span>
+      </button>
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1
+        return (
+          <div key={item.id} className="flex items-center gap-1">
+            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+            <button
+              type="button"
+              onClick={() => onNavigate(item.id)}
+              className={cn(
+                'rounded-md px-2 py-1 transition-colors',
+                isLast
+                  ? 'font-medium text-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+              )}
+            >
+              {item.name}
+            </button>
+          </div>
+        )
+      })}
+    </nav>
+  )
+}

--- a/components/dashboard/folder/folder-card.tsx
+++ b/components/dashboard/folder/folder-card.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import {
+  FolderInput,
+  Folder as FolderIcon,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+} from 'lucide-react'
+
+import { Card } from '@/components/ui/card'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+import { getColorClasses } from '@/lib/organization/colors'
+import { cn } from '@/lib/utils'
+
+import type { FolderTreeNode } from '@/types/components/folder'
+
+interface FolderCardProps {
+  folder: FolderTreeNode
+  onOpen: (id: string) => void
+  onRename: (folder: FolderTreeNode) => void
+  onMove: (folder: FolderTreeNode) => void
+  onDelete: (folder: FolderTreeNode) => void
+}
+
+export function FolderCard({
+  folder,
+  onOpen,
+  onRename,
+  onMove,
+  onDelete,
+}: FolderCardProps) {
+  const classes = getColorClasses(folder.color)
+  const childCount = folder.children.length
+
+  return (
+    <Card
+      onClick={() => onOpen(folder.id)}
+      className="group relative flex items-center gap-3 p-4 cursor-pointer bg-background/40 backdrop-blur-xl border-border/50 shadow-sm hover:shadow-lg hover:bg-background/60 transition-all duration-200"
+    >
+      <div
+        className={cn(
+          'flex h-11 w-11 items-center justify-center rounded-lg bg-muted/50 shrink-0',
+          classes.icon
+        )}
+      >
+        <FolderIcon className="h-6 w-6" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="font-medium truncate">{folder.name}</p>
+        <p className="text-xs text-muted-foreground">
+          {folder.totalFileCount} file{folder.totalFileCount === 1 ? '' : 's'}
+          {childCount > 0 &&
+            ` · ${childCount} folder${childCount === 1 ? '' : 's'}`}
+        </p>
+      </div>
+      <div onClick={(e) => e.stopPropagation()}>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="p-1.5 rounded-md opacity-0 group-hover:opacity-100 hover:bg-accent transition-opacity"
+              aria-label="Folder actions"
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onRename(folder)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              Rename / recolor
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onMove(folder)}>
+              <FolderInput className="mr-2 h-4 w-4" />
+              Move
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => onDelete(folder)}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </Card>
+  )
+}

--- a/components/dashboard/folder/folder-card.tsx
+++ b/components/dashboard/folder/folder-card.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import type { FolderTreeNode } from '@/types/components/folder'
 import {
-  FolderInput,
   Folder as FolderIcon,
+  FolderInput,
   MoreHorizontal,
   Pencil,
   Trash2,
@@ -19,8 +20,6 @@ import {
 
 import { getColorClasses } from '@/lib/organization/colors'
 import { cn } from '@/lib/utils'
-
-import type { FolderTreeNode } from '@/types/components/folder'
 
 interface FolderCardProps {
   folder: FolderTreeNode

--- a/components/dashboard/folder/folder-dialog.tsx
+++ b/components/dashboard/folder/folder-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 
+import { ColorPicker } from '@/components/dashboard/folder/color-picker'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -11,8 +12,6 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-
-import { ColorPicker } from '@/components/dashboard/folder/color-picker'
 
 import type { OrganizationColor } from '@/lib/organization/colors'
 
@@ -92,7 +91,10 @@ export function FolderDialog({
             <Button variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button onClick={handleSubmit} disabled={!name.trim() || submitting}>
+            <Button
+              onClick={handleSubmit}
+              disabled={!name.trim() || submitting}
+            >
               {mode === 'create' ? 'Create' : 'Save'}
             </Button>
           </div>

--- a/components/dashboard/folder/folder-dialog.tsx
+++ b/components/dashboard/folder/folder-dialog.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+import { ColorPicker } from '@/components/dashboard/folder/color-picker'
+
+import type { OrganizationColor } from '@/lib/organization/colors'
+
+interface FolderDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  mode: 'create' | 'rename'
+  initialName?: string
+  initialColor?: string | null
+  onSubmit: (values: {
+    name: string
+    color: OrganizationColor | null
+  }) => Promise<boolean | void> | void
+}
+
+export function FolderDialog({
+  open,
+  onOpenChange,
+  mode,
+  initialName = '',
+  initialColor = null,
+  onSubmit,
+}: FolderDialogProps) {
+  const [name, setName] = useState(initialName)
+  const [color, setColor] = useState<OrganizationColor | null>(
+    (initialColor as OrganizationColor) ?? null
+  )
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setName(initialName)
+      setColor((initialColor as OrganizationColor) ?? null)
+    }
+  }, [open, initialName, initialColor])
+
+  const handleSubmit = async () => {
+    if (!name.trim()) return
+    setSubmitting(true)
+    const result = await onSubmit({ name: name.trim(), color })
+    setSubmitting(false)
+    if (result !== false) {
+      onOpenChange(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {mode === 'create' ? 'New Folder' : 'Rename Folder'}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="folder-name">Name</Label>
+            <Input
+              id="folder-name"
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  handleSubmit()
+                }
+              }}
+              placeholder="e.g. Screenshots"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Color</Label>
+            <ColorPicker value={color} onChange={setColor} />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} disabled={!name.trim() || submitting}>
+              {mode === 'create' ? 'Create' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/dashboard/folder/folder-filter.tsx
+++ b/components/dashboard/folder/folder-filter.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { FolderTreeNode } from '@/types/components/folder'
 import { Check, Files, Folder as FolderIcon } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -14,8 +15,6 @@ import {
 
 import { getColorClasses } from '@/lib/organization/colors'
 import { cn } from '@/lib/utils'
-
-import type { FolderTreeNode } from '@/types/components/folder'
 
 interface FolderFilterProps {
   tree: FolderTreeNode[]
@@ -58,7 +57,10 @@ export function FolderFilter({ tree, value, onChange }: FolderFilterProps) {
         <DropdownMenuLabel>Filter by folder</DropdownMenuLabel>
         <DropdownMenuItem
           onClick={() => onChange(null)}
-          className={cn('flex items-center justify-between', value === null && 'bg-accent')}
+          className={cn(
+            'flex items-center justify-between',
+            value === null && 'bg-accent'
+          )}
         >
           <span className="flex items-center gap-2">
             <Files className="h-4 w-4 text-muted-foreground" />

--- a/components/dashboard/folder/folder-filter.tsx
+++ b/components/dashboard/folder/folder-filter.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { Check, Files, Folder as FolderIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+import { getColorClasses } from '@/lib/organization/colors'
+import { cn } from '@/lib/utils'
+
+import type { FolderTreeNode } from '@/types/components/folder'
+
+interface FolderFilterProps {
+  tree: FolderTreeNode[]
+  value: string | null
+  onChange: (folderId: string | null) => void
+}
+
+function flatten(
+  nodes: FolderTreeNode[],
+  depth: number
+): { node: FolderTreeNode; depth: number }[] {
+  return nodes.flatMap((node) => [
+    { node, depth },
+    ...flatten(node.children, depth + 1),
+  ])
+}
+
+export function FolderFilter({ tree, value, onChange }: FolderFilterProps) {
+  const flat = flatten(tree, 0)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className="min-w-[120px] flex items-center justify-between bg-background/60 backdrop-blur-sm border-border/50 hover:bg-background/80 transition-all duration-200"
+        >
+          <span>Folder</span>
+          {value ? (
+            <span className="ml-2 h-2 w-2 rounded-full bg-primary" />
+          ) : (
+            <FolderIcon className="ml-2 h-4 w-4" />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-60 max-h-[400px] overflow-y-auto"
+      >
+        <DropdownMenuLabel>Filter by folder</DropdownMenuLabel>
+        <DropdownMenuItem
+          onClick={() => onChange(null)}
+          className={cn('flex items-center justify-between', value === null && 'bg-accent')}
+        >
+          <span className="flex items-center gap-2">
+            <Files className="h-4 w-4 text-muted-foreground" />
+            All files
+          </span>
+          {value === null && <Check className="h-4 w-4" />}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => onChange('none')}
+          className={cn(
+            'flex items-center justify-between',
+            value === 'none' && 'bg-accent'
+          )}
+        >
+          <span className="flex items-center gap-2">
+            <FolderIcon className="h-4 w-4 text-muted-foreground" />
+            Unfiled
+          </span>
+          {value === 'none' && <Check className="h-4 w-4" />}
+        </DropdownMenuItem>
+        {flat.length > 0 && <DropdownMenuSeparator />}
+        {flat.map(({ node, depth }) => {
+          const classes = getColorClasses(node.color)
+          const selected = value === node.id
+          return (
+            <DropdownMenuItem
+              key={node.id}
+              onClick={() => onChange(node.id)}
+              className={cn(
+                'flex items-center justify-between',
+                selected && 'bg-accent'
+              )}
+              style={{ paddingLeft: `${8 + depth * 14}px` }}
+            >
+              <span className="flex items-center gap-2 min-w-0">
+                <FolderIcon className={cn('h-4 w-4 shrink-0', classes.icon)} />
+                <span className="truncate">{node.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  {node.totalFileCount}
+                </span>
+              </span>
+              {selected && <Check className="ml-2 h-4 w-4 shrink-0" />}
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/dashboard/folder/folder-sidebar.tsx
+++ b/components/dashboard/folder/folder-sidebar.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from 'react'
 
+import type { FolderTreeNode } from '@/types/components/folder'
 import {
   ChevronRight,
   Files,
-  FolderInput,
   Folder as FolderIcon,
+  FolderInput,
   FolderPlus,
   MoreHorizontal,
   Pencil,
@@ -24,8 +25,6 @@ import {
 
 import { getColorClasses } from '@/lib/organization/colors'
 import { cn } from '@/lib/utils'
-
-import type { FolderTreeNode } from '@/types/components/folder'
 
 export interface FolderSidebarProps {
   tree: FolderTreeNode[]
@@ -54,7 +53,12 @@ function FolderNode({
   depth: number
 } & Pick<
   FolderSidebarProps,
-  'selectedFolderId' | 'onSelect' | 'onCreateChild' | 'onRename' | 'onMove' | 'onDelete'
+  | 'selectedFolderId'
+  | 'onSelect'
+  | 'onCreateChild'
+  | 'onRename'
+  | 'onMove'
+  | 'onDelete'
 >) {
   const [expanded, setExpanded] = useState(false)
   const classes = getColorClasses(node.color)
@@ -77,7 +81,10 @@ function FolderNode({
             aria-label={expanded ? 'Collapse' : 'Expand'}
           >
             <ChevronRight
-              className={cn('h-3.5 w-3.5 transition-transform', expanded && 'rotate-90')}
+              className={cn(
+                'h-3.5 w-3.5 transition-transform',
+                expanded && 'rotate-90'
+              )}
             />
           </button>
         ) : (

--- a/components/dashboard/folder/folder-sidebar.tsx
+++ b/components/dashboard/folder/folder-sidebar.tsx
@@ -1,0 +1,227 @@
+'use client'
+
+import { useState } from 'react'
+
+import {
+  ChevronRight,
+  Files,
+  FolderInput,
+  Folder as FolderIcon,
+  FolderPlus,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+} from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+import { getColorClasses } from '@/lib/organization/colors'
+import { cn } from '@/lib/utils'
+
+import type { FolderTreeNode } from '@/types/components/folder'
+
+export interface FolderSidebarProps {
+  tree: FolderTreeNode[]
+  totalFileCount: number
+  unfiledCount?: number
+  selectedFolderId: string | null
+  onSelect: (folderId: string | null) => void
+  onCreateRoot: () => void
+  onCreateChild: (parentId: string) => void
+  onRename: (node: FolderTreeNode) => void
+  onMove: (node: FolderTreeNode) => void
+  onDelete: (node: FolderTreeNode) => void
+}
+
+function FolderNode({
+  node,
+  depth,
+  selectedFolderId,
+  onSelect,
+  onCreateChild,
+  onRename,
+  onMove,
+  onDelete,
+}: {
+  node: FolderTreeNode
+  depth: number
+} & Pick<
+  FolderSidebarProps,
+  'selectedFolderId' | 'onSelect' | 'onCreateChild' | 'onRename' | 'onMove' | 'onDelete'
+>) {
+  const [expanded, setExpanded] = useState(false)
+  const classes = getColorClasses(node.color)
+  const isActive = selectedFolderId === node.id
+
+  return (
+    <div>
+      <div
+        className={cn(
+          'group flex items-center gap-1 rounded-md pr-1 transition-colors',
+          isActive ? 'bg-accent' : 'hover:bg-accent/50'
+        )}
+        style={{ paddingLeft: `${depth * 14}px` }}
+      >
+        {node.children.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="p-1 rounded hover:bg-accent shrink-0"
+            aria-label={expanded ? 'Collapse' : 'Expand'}
+          >
+            <ChevronRight
+              className={cn('h-3.5 w-3.5 transition-transform', expanded && 'rotate-90')}
+            />
+          </button>
+        ) : (
+          <span className="w-[22px] shrink-0" />
+        )}
+        <button
+          type="button"
+          onClick={() => onSelect(node.id)}
+          className="flex flex-1 items-center gap-2 py-1.5 text-sm min-w-0 text-left"
+        >
+          <FolderIcon className={cn('h-4 w-4 shrink-0', classes.icon)} />
+          <span className="truncate">{node.name}</span>
+          <span className="ml-auto text-xs text-muted-foreground shrink-0">
+            {node.totalFileCount || ''}
+          </span>
+        </button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="p-1 rounded opacity-0 group-hover:opacity-100 hover:bg-accent shrink-0 transition-opacity"
+              aria-label="Folder actions"
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onCreateChild(node.id)}>
+              <FolderPlus className="mr-2 h-4 w-4" />
+              New subfolder
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onRename(node)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              Rename / recolor
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onMove(node)}>
+              <FolderInput className="mr-2 h-4 w-4" />
+              Move
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => onDelete(node)}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {expanded &&
+        node.children.map((child) => (
+          <FolderNode
+            key={child.id}
+            node={child}
+            depth={depth + 1}
+            selectedFolderId={selectedFolderId}
+            onSelect={onSelect}
+            onCreateChild={onCreateChild}
+            onRename={onRename}
+            onMove={onMove}
+            onDelete={onDelete}
+          />
+        ))}
+    </div>
+  )
+}
+
+export function FolderSidebar({
+  tree,
+  totalFileCount,
+  unfiledCount,
+  selectedFolderId,
+  onSelect,
+  onCreateRoot,
+  onCreateChild,
+  onRename,
+  onMove,
+  onDelete,
+}: FolderSidebarProps) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between px-1 pb-1">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Folders
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={onCreateRoot}
+          aria-label="New folder"
+        >
+          <FolderPlus className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onSelect(null)}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+          selectedFolderId === null ? 'bg-accent' : 'hover:bg-accent/50'
+        )}
+      >
+        <Files className="h-4 w-4 text-muted-foreground" />
+        <span>All files</span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {totalFileCount || ''}
+        </span>
+      </button>
+
+      <button
+        type="button"
+        onClick={() => onSelect('none')}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+          selectedFolderId === 'none' ? 'bg-accent' : 'hover:bg-accent/50'
+        )}
+      >
+        <FolderIcon className="h-4 w-4 text-muted-foreground" />
+        <span>Unfiled</span>
+        {unfiledCount !== undefined && (
+          <span className="ml-auto text-xs text-muted-foreground">
+            {unfiledCount || ''}
+          </span>
+        )}
+      </button>
+
+      <div className="pt-1">
+        {tree.map((node) => (
+          <FolderNode
+            key={node.id}
+            node={node}
+            depth={0}
+            selectedFolderId={selectedFolderId}
+            onSelect={onSelect}
+            onCreateChild={onCreateChild}
+            onRename={onRename}
+            onMove={onMove}
+            onDelete={onDelete}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/folder/move-to-folder-dialog.tsx
+++ b/components/dashboard/folder/move-to-folder-dialog.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useState } from 'react'
+
+import { ChevronRight, Folder as FolderIcon, FolderInput, Home } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+import { getColorClasses } from '@/lib/organization/colors'
+import { cn } from '@/lib/utils'
+
+import type { FolderTreeNode } from '@/types/components/folder'
+
+interface MoveToFolderDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  tree: FolderTreeNode[]
+  // Folder ids that cannot be selected as a destination (e.g. the folder being
+  // moved and its descendants).
+  disabledIds?: Set<string>
+  title?: string
+  onSelect: (folderId: string | null) => Promise<boolean | void> | void
+}
+
+function FolderRow({
+  node,
+  depth,
+  disabledIds,
+  onSelect,
+}: {
+  node: FolderTreeNode
+  depth: number
+  disabledIds: Set<string>
+  onSelect: (id: string) => void
+}) {
+  const [expanded, setExpanded] = useState(true)
+  const classes = getColorClasses(node.color)
+  const disabled = disabledIds.has(node.id)
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-1"
+        style={{ paddingLeft: `${depth * 16}px` }}
+      >
+        {node.children.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="p-0.5 rounded hover:bg-accent"
+          >
+            <ChevronRight
+              className={cn(
+                'h-4 w-4 transition-transform',
+                expanded && 'rotate-90'
+              )}
+            />
+          </button>
+        ) : (
+          <span className="w-5" />
+        )}
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onSelect(node.id)}
+          className={cn(
+            'flex flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors text-left',
+            disabled && 'opacity-40 cursor-not-allowed hover:bg-transparent'
+          )}
+        >
+          <FolderIcon className={cn('h-4 w-4 shrink-0', classes.icon)} />
+          <span className="truncate">{node.name}</span>
+        </button>
+      </div>
+      {expanded &&
+        node.children.map((child) => (
+          <FolderRow
+            key={child.id}
+            node={child}
+            depth={depth + 1}
+            disabledIds={disabledIds}
+            onSelect={onSelect}
+          />
+        ))}
+    </div>
+  )
+}
+
+export function MoveToFolderDialog({
+  open,
+  onOpenChange,
+  tree,
+  disabledIds = new Set(),
+  title = 'Move to folder',
+  onSelect,
+}: MoveToFolderDialogProps) {
+  const handleSelect = async (folderId: string | null) => {
+    const result = await onSelect(folderId)
+    if (result !== false) {
+      onOpenChange(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FolderInput className="h-4 w-4" />
+            {title}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-1 py-2 max-h-[360px] overflow-y-auto">
+          <button
+            type="button"
+            onClick={() => handleSelect(null)}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors text-left"
+          >
+            <Home className="h-4 w-4 text-muted-foreground" />
+            <span>No folder (root)</span>
+          </button>
+          {tree.map((node) => (
+            <FolderRow
+              key={node.id}
+              node={node}
+              depth={0}
+              disabledIds={disabledIds}
+              onSelect={handleSelect}
+            />
+          ))}
+          {tree.length === 0 && (
+            <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+              No folders yet. Create one first.
+            </p>
+          )}
+        </div>
+        <div className="flex justify-end">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/dashboard/folder/move-to-folder-dialog.tsx
+++ b/components/dashboard/folder/move-to-folder-dialog.tsx
@@ -2,7 +2,13 @@
 
 import { useState } from 'react'
 
-import { ChevronRight, Folder as FolderIcon, FolderInput, Home } from 'lucide-react'
+import type { FolderTreeNode } from '@/types/components/folder'
+import {
+  ChevronRight,
+  Folder as FolderIcon,
+  FolderInput,
+  Home,
+} from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -14,8 +20,6 @@ import {
 
 import { getColorClasses } from '@/lib/organization/colors'
 import { cn } from '@/lib/utils'
-
-import type { FolderTreeNode } from '@/types/components/folder'
 
 interface MoveToFolderDialogProps {
   open: boolean

--- a/components/dashboard/tag/manage-tags-dialog.tsx
+++ b/components/dashboard/tag/manage-tags-dialog.tsx
@@ -2,8 +2,10 @@
 
 import { useState } from 'react'
 
+import type { Tag } from '@/types/components/tag'
 import { Check, Pencil, Plus, Trash2, X } from 'lucide-react'
 
+import { ColorPicker } from '@/components/dashboard/folder/color-picker'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -14,13 +16,9 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 
-import { ColorPicker } from '@/components/dashboard/folder/color-picker'
-
 import { getColorClasses } from '@/lib/organization/colors'
 import type { OrganizationColor } from '@/lib/organization/colors'
 import { cn } from '@/lib/utils'
-
-import type { Tag } from '@/types/components/tag'
 
 interface ManageTagsDialogProps {
   open: boolean
@@ -101,7 +99,11 @@ export function ManageTagsDialog({
             />
             <div className="flex items-center justify-between gap-2">
               <ColorPicker value={newColor} onChange={setNewColor} />
-              <Button size="sm" onClick={handleCreate} disabled={!newName.trim()}>
+              <Button
+                size="sm"
+                onClick={handleCreate}
+                disabled={!newName.trim()}
+              >
                 <Plus className="mr-1 h-4 w-4" />
                 Add
               </Button>

--- a/components/dashboard/tag/manage-tags-dialog.tsx
+++ b/components/dashboard/tag/manage-tags-dialog.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Check, Pencil, Plus, Trash2, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+
+import { ColorPicker } from '@/components/dashboard/folder/color-picker'
+
+import { getColorClasses } from '@/lib/organization/colors'
+import type { OrganizationColor } from '@/lib/organization/colors'
+import { cn } from '@/lib/utils'
+
+import type { Tag } from '@/types/components/tag'
+
+interface ManageTagsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  tags: Tag[]
+  onCreate: (input: {
+    name: string
+    color: OrganizationColor | null
+  }) => Promise<Tag | null>
+  onUpdate: (
+    id: string,
+    input: { name?: string; color?: OrganizationColor | null }
+  ) => Promise<boolean>
+  onDelete: (id: string) => Promise<boolean>
+}
+
+export function ManageTagsDialog({
+  open,
+  onOpenChange,
+  tags,
+  onCreate,
+  onUpdate,
+  onDelete,
+}: ManageTagsDialogProps) {
+  const [newName, setNewName] = useState('')
+  const [newColor, setNewColor] = useState<OrganizationColor | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+  const [editColor, setEditColor] = useState<OrganizationColor | null>(null)
+
+  const startEdit = (tag: Tag) => {
+    setEditingId(tag.id)
+    setEditName(tag.name)
+    setEditColor((tag.color as OrganizationColor) ?? null)
+  }
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return
+    const created = await onCreate({ name: newName.trim(), color: newColor })
+    if (created) {
+      setNewName('')
+      setNewColor(null)
+    }
+  }
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !editName.trim()) return
+    const ok = await onUpdate(editingId, {
+      name: editName.trim(),
+      color: editColor,
+    })
+    if (ok) setEditingId(null)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Manage Tags</DialogTitle>
+          <DialogDescription>
+            Create, rename, recolor, or delete your tags. Deleting a tag keeps
+            your files; it only removes the label.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <div className="rounded-lg border border-border/50 p-3 space-y-3">
+            <Input
+              placeholder="New tag name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  handleCreate()
+                }
+              }}
+            />
+            <div className="flex items-center justify-between gap-2">
+              <ColorPicker value={newColor} onChange={setNewColor} />
+              <Button size="sm" onClick={handleCreate} disabled={!newName.trim()}>
+                <Plus className="mr-1 h-4 w-4" />
+                Add
+              </Button>
+            </div>
+          </div>
+
+          <div className="max-h-[320px] overflow-y-auto space-y-1">
+            {tags.length === 0 && (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                No tags yet
+              </p>
+            )}
+            {tags.map((tag) => {
+              const classes = getColorClasses(tag.color)
+              const isEditing = editingId === tag.id
+              return (
+                <div
+                  key={tag.id}
+                  className="rounded-md border border-border/40 p-2"
+                >
+                  {isEditing ? (
+                    <div className="space-y-2">
+                      <Input
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                        className="h-8"
+                      />
+                      <div className="flex items-center justify-between gap-2">
+                        <ColorPicker
+                          value={editColor}
+                          onChange={setEditColor}
+                        />
+                        <div className="flex gap-1">
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-8 w-8"
+                            onClick={() => setEditingId(null)}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={handleSaveEdit}
+                          >
+                            <Check className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span
+                          className={cn(
+                            'h-3 w-3 rounded-full shrink-0',
+                            classes.dot
+                          )}
+                        />
+                        <span className="truncate text-sm font-medium">
+                          {tag.name}
+                        </span>
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          {tag.fileCount} file{tag.fileCount === 1 ? '' : 's'}
+                        </span>
+                      </div>
+                      <div className="flex gap-1 shrink-0">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-8 w-8"
+                          onClick={() => startEdit(tag)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-8 w-8 text-destructive hover:text-destructive"
+                          onClick={() => onDelete(tag.id)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/dashboard/tag/tag-badge.tsx
+++ b/components/dashboard/tag/tag-badge.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { X } from 'lucide-react'
+
+import { getColorClasses } from '@/lib/organization/colors'
+import { cn } from '@/lib/utils'
+
+interface TagBadgeProps {
+  name: string
+  color?: string | null
+  className?: string
+  onRemove?: () => void
+  onClick?: () => void
+}
+
+export function TagBadge({
+  name,
+  color,
+  className,
+  onRemove,
+  onClick,
+}: TagBadgeProps) {
+  const classes = getColorClasses(color ?? null)
+
+  return (
+    <span
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium max-w-full',
+        classes.badge,
+        onClick && 'cursor-pointer hover:opacity-80 transition-opacity',
+        className
+      )}
+    >
+      <span className="truncate">{name}</span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onRemove()
+          }}
+          className="shrink-0 rounded-full hover:bg-black/10 dark:hover:bg-white/10"
+          aria-label={`Remove ${name} tag`}
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </span>
+  )
+}

--- a/components/dashboard/tag/tag-filter.tsx
+++ b/components/dashboard/tag/tag-filter.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { Tag } from '@/types/components/tag'
 import { Check, Settings2, Tag as TagIcon } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -14,8 +15,6 @@ import {
 
 import { getColorClasses } from '@/lib/organization/colors'
 import { cn } from '@/lib/utils'
-
-import type { Tag } from '@/types/components/tag'
 
 interface TagFilterProps {
   tags: Tag[]
@@ -79,7 +78,12 @@ export function TagFilter({
               )}
             >
               <div className="flex items-center gap-2 min-w-0">
-                <span className={cn('h-2.5 w-2.5 rounded-full shrink-0', classes.dot)} />
+                <span
+                  className={cn(
+                    'h-2.5 w-2.5 rounded-full shrink-0',
+                    classes.dot
+                  )}
+                />
                 <span className="truncate">{tag.name}</span>
                 <span className="text-xs text-muted-foreground">
                   {tag.fileCount}

--- a/components/dashboard/tag/tag-filter.tsx
+++ b/components/dashboard/tag/tag-filter.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { Check, Settings2, Tag as TagIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+import { getColorClasses } from '@/lib/organization/colors'
+import { cn } from '@/lib/utils'
+
+import type { Tag } from '@/types/components/tag'
+
+interface TagFilterProps {
+  tags: Tag[]
+  selectedIds: string[]
+  onChange: (ids: string[]) => void
+  onManage?: () => void
+}
+
+export function TagFilter({
+  tags,
+  selectedIds,
+  onChange,
+  onManage,
+}: TagFilterProps) {
+  const toggle = (id: string) => {
+    onChange(
+      selectedIds.includes(id)
+        ? selectedIds.filter((t) => t !== id)
+        : [...selectedIds, id]
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className="min-w-[120px] flex items-center justify-between bg-background/60 backdrop-blur-sm border-border/50 hover:bg-background/80 transition-all duration-200"
+        >
+          <span>Tags</span>
+          {selectedIds.length > 0 ? (
+            <span className="ml-2 rounded-full bg-primary w-5 h-5 flex items-center justify-center text-[10px] font-medium text-primary-foreground">
+              {selectedIds.length}
+            </span>
+          ) : (
+            <TagIcon className="ml-2 h-4 w-4" />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-60 max-h-[400px] overflow-y-auto"
+      >
+        <DropdownMenuLabel>Filter by tag</DropdownMenuLabel>
+        {tags.length === 0 && (
+          <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+            No tags yet
+          </div>
+        )}
+        {tags.map((tag) => {
+          const classes = getColorClasses(tag.color)
+          const selected = selectedIds.includes(tag.id)
+          return (
+            <DropdownMenuItem
+              key={tag.id}
+              onClick={() => toggle(tag.id)}
+              onSelect={(e) => e.preventDefault()}
+              className={cn(
+                'flex items-center justify-between',
+                selected && 'bg-accent'
+              )}
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span className={cn('h-2.5 w-2.5 rounded-full shrink-0', classes.dot)} />
+                <span className="truncate">{tag.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  {tag.fileCount}
+                </span>
+              </div>
+              {selected && <Check className="ml-2 h-4 w-4 shrink-0" />}
+            </DropdownMenuItem>
+          )
+        })}
+        {onManage && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={onManage}>
+              <Settings2 className="mr-2 h-4 w-4" />
+              Manage tags
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/dashboard/tag/tag-picker.tsx
+++ b/components/dashboard/tag/tag-picker.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { Check, Plus, Tag as TagIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+
+import { getColorClasses } from '@/lib/organization/colors'
+import { cn } from '@/lib/utils'
+
+import type { Tag } from '@/types/components/tag'
+
+interface TagPickerProps {
+  tags: Tag[]
+  selectedIds: string[]
+  onToggle: (tagId: string) => void
+  onCreate?: (name: string) => Promise<Tag | null>
+  trigger?: React.ReactNode
+  align?: 'start' | 'center' | 'end'
+}
+
+export function TagPicker({
+  tags,
+  selectedIds,
+  onToggle,
+  onCreate,
+  trigger,
+  align = 'start',
+}: TagPickerProps) {
+  const [search, setSearch] = useState('')
+  const [creating, setCreating] = useState(false)
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return tags
+    return tags.filter((t) => t.name.toLowerCase().includes(q))
+  }, [tags, search])
+
+  const exactMatch = tags.some(
+    (t) => t.name.toLowerCase() === search.trim().toLowerCase()
+  )
+  const canCreate = Boolean(onCreate) && search.trim().length > 0 && !exactMatch
+
+  const handleCreate = async () => {
+    if (!onCreate) return
+    setCreating(true)
+    const created = await onCreate(search.trim())
+    setCreating(false)
+    if (created) {
+      onToggle(created.id)
+      setSearch('')
+    }
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        {trigger ?? (
+          <Button variant="outline" size="sm" className="gap-2">
+            <TagIcon className="h-4 w-4" />
+            Tags
+          </Button>
+        )}
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align={align}>
+        <div className="p-2 border-b border-border/50">
+          <Input
+            autoFocus
+            placeholder="Search or create..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && canCreate) {
+                e.preventDefault()
+                handleCreate()
+              }
+            }}
+            className="h-8"
+          />
+        </div>
+        <div className="max-h-[240px] overflow-y-auto p-1">
+          {filtered.map((tag) => {
+            const selected = selectedIds.includes(tag.id)
+            const classes = getColorClasses(tag.color)
+            return (
+              <button
+                key={tag.id}
+                type="button"
+                onClick={() => onToggle(tag.id)}
+                className={cn(
+                  'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors',
+                  selected && 'bg-accent/60'
+                )}
+              >
+                <span className="flex items-center gap-2 min-w-0">
+                  <span
+                    className={cn('h-2.5 w-2.5 rounded-full shrink-0', classes.dot)}
+                  />
+                  <span className="truncate">{tag.name}</span>
+                </span>
+                {selected && <Check className="h-4 w-4 shrink-0" />}
+              </button>
+            )
+          })}
+          {filtered.length === 0 && !canCreate && (
+            <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+              No tags found
+            </p>
+          )}
+          {canCreate && (
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={creating}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors disabled:opacity-50"
+            >
+              <Plus className="h-4 w-4" />
+              Create &ldquo;{search.trim()}&rdquo;
+            </button>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/dashboard/tag/tag-picker.tsx
+++ b/components/dashboard/tag/tag-picker.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 
+import type { Tag } from '@/types/components/tag'
 import { Check, Plus, Tag as TagIcon } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -14,8 +15,6 @@ import {
 
 import { getColorClasses } from '@/lib/organization/colors'
 import { cn } from '@/lib/utils'
-
-import type { Tag } from '@/types/components/tag'
 
 interface TagPickerProps {
   tags: Tag[]
@@ -101,7 +100,10 @@ export function TagPicker({
               >
                 <span className="flex items-center gap-2 min-w-0">
                   <span
-                    className={cn('h-2.5 w-2.5 rounded-full shrink-0', classes.dot)}
+                    className={cn(
+                      'h-2.5 w-2.5 rounded-full shrink-0',
+                      classes.dot
+                    )}
                   />
                   <span className="truncate">{tag.name}</span>
                 </span>

--- a/components/file/upload-form.tsx
+++ b/components/file/upload-form.tsx
@@ -4,13 +4,13 @@ import { useState } from 'react'
 
 import Image from 'next/image'
 
+import type { FolderTreeNode } from '@/types/components/folder'
 import { ExpiryAction } from '@/types/events'
 import { $Enums } from '@prisma/client'
 import { format } from 'date-fns'
 import { CalendarIcon, FileIcon, UploadIcon, XIcon } from 'lucide-react'
-import { useDropzone } from 'react-dropzone'
-
 import { Plus } from 'lucide-react'
+import { useDropzone } from 'react-dropzone'
 
 import { TagBadge } from '@/components/dashboard/tag/tag-badge'
 import { TagPicker } from '@/components/dashboard/tag/tag-picker'
@@ -33,8 +33,6 @@ import { formatBytes } from '@/lib/utils'
 import { FileWithPreview, useFileUpload } from '@/hooks/use-file-upload'
 import { useFolders } from '@/hooks/use-folders'
 import { useTags } from '@/hooks/use-tags'
-
-import type { FolderTreeNode } from '@/types/components/folder'
 
 interface UploadFormProps {
   maxSize: number

--- a/components/file/upload-form.tsx
+++ b/components/file/upload-form.tsx
@@ -10,6 +10,10 @@ import { format } from 'date-fns'
 import { CalendarIcon, FileIcon, UploadIcon, XIcon } from 'lucide-react'
 import { useDropzone } from 'react-dropzone'
 
+import { Plus } from 'lucide-react'
+
+import { TagBadge } from '@/components/dashboard/tag/tag-badge'
+import { TagPicker } from '@/components/dashboard/tag/tag-picker'
 import { ExpiryModal } from '@/components/shared/expiry-modal'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -27,14 +31,29 @@ import {
 import { formatBytes } from '@/lib/utils'
 
 import { FileWithPreview, useFileUpload } from '@/hooks/use-file-upload'
+import { useFolders } from '@/hooks/use-folders'
+import { useTags } from '@/hooks/use-tags'
+
+import type { FolderTreeNode } from '@/types/components/folder'
 
 interface UploadFormProps {
   maxSize: number
   formattedMaxSize: string
+  organizationEnabled?: boolean
   user: {
     defaultFileExpiration: $Enums.FileExpiration | null
     defaultFileExpirationAction: $Enums.ExpiryAction | null
   }
+}
+
+function flattenFolders(
+  nodes: FolderTreeNode[],
+  depth: number
+): { id: string; name: string; depth: number }[] {
+  return nodes.flatMap((node) => [
+    { id: node.id, name: node.name, depth },
+    ...flattenFolders(node.children, depth + 1),
+  ])
 }
 
 const getDefaultExpiryDate = (unit: $Enums.FileExpiration | null) => {
@@ -66,6 +85,7 @@ const getDefaultExpiryDate = (unit: $Enums.FileExpiration | null) => {
 export function UploadForm({
   maxSize,
   formattedMaxSize,
+  organizationEnabled = false,
   user,
 }: UploadFormProps) {
   const [isExpiryModalOpen, setIsExpiryModalOpen] = useState(false)
@@ -82,10 +102,28 @@ export function UploadForm({
     setPassword,
     expiresAt,
     setExpiresAt,
+    folderId,
+    setFolderId,
+    tags: selectedTagIds,
+    setTags: setSelectedTagIds,
   } = useFileUpload({
     maxSize,
     expiresAt: getDefaultExpiryDate(user.defaultFileExpiration),
   })
+
+  const { tree } = useFolders({ enabled: organizationEnabled })
+  const { tags, createTag } = useTags({ enabled: organizationEnabled })
+
+  const flatFolders = flattenFolders(tree, 0)
+  const selectedTags = tags.filter((t) => selectedTagIds.includes(t.id))
+
+  const toggleTag = (tagId: string) => {
+    setSelectedTagIds(
+      selectedTagIds.includes(tagId)
+        ? selectedTagIds.filter((t) => t !== tagId)
+        : [...selectedTagIds, tagId]
+    )
+  }
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
@@ -183,6 +221,59 @@ export function UploadForm({
             </SelectContent>
           </Select>
         </div>
+
+        {organizationEnabled && (
+          <>
+            <div className="space-y-2">
+              <Label>Folder (Optional)</Label>
+              <Select
+                value={folderId ?? 'none'}
+                onValueChange={(value) =>
+                  setFolderId(value === 'none' ? null : value)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="No folder" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No folder</SelectItem>
+                  {flatFolders.map((folder) => (
+                    <SelectItem key={folder.id} value={folder.id}>
+                      {'\u00A0'.repeat(folder.depth * 2)}
+                      {folder.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Tags (Optional)</Label>
+              <div className="flex flex-wrap items-center gap-1.5">
+                {selectedTags.map((tag) => (
+                  <TagBadge
+                    key={tag.id}
+                    name={tag.name}
+                    color={tag.color}
+                    onRemove={() => toggleTag(tag.id)}
+                  />
+                ))}
+                <TagPicker
+                  tags={tags}
+                  selectedIds={selectedTagIds}
+                  onToggle={toggleTag}
+                  onCreate={(name) => createTag({ name })}
+                  trigger={
+                    <Button variant="outline" size="sm" className="gap-1.5 h-7">
+                      <Plus className="h-3.5 w-3.5" />
+                      Add tag
+                    </Button>
+                  }
+                />
+              </div>
+            </div>
+          </>
+        )}
 
         <div className="space-y-2">
           <Label>Password Protection (Optional)</Label>

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -28,9 +28,7 @@ const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
         }}
         className={cn(
           'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 flex items-center justify-center transition-colors',
-          checked
-            ? 'bg-primary text-primary-foreground'
-            : 'bg-background/80',
+          checked ? 'bg-primary text-primary-foreground' : 'bg-background/80',
           className
         )}
         {...props}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import * as React from 'react'
+
+import { Check } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+interface CheckboxProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
+  checked?: boolean
+  onCheckedChange?: (checked: boolean) => void
+}
+
+// A minimal, dependency-free checkbox styled to match the shadcn/ui look.
+const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
+  ({ className, checked = false, onCheckedChange, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="checkbox"
+        aria-checked={checked}
+        onClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          onCheckedChange?.(!checked)
+        }}
+        className={cn(
+          'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 flex items-center justify-center transition-colors',
+          checked
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-background/80',
+          className
+        )}
+        {...props}
+      >
+        {checked && <Check className="h-3 w-3" />}
+      </button>
+    )
+  }
+)
+Checkbox.displayName = 'Checkbox'
+
+export { Checkbox }

--- a/hooks/use-file-filters.ts
+++ b/hooks/use-file-filters.ts
@@ -6,7 +6,19 @@ import {
   FileFilter,
   FileFilterOptions,
   SortOption,
+  ViewMode,
 } from '@/types/components/file'
+
+const VIEW_STORAGE_KEY = 'flare:dashboard:view'
+const VALID_VIEWS: ViewMode[] = ['grid', 'list', 'folder']
+
+function readStoredView(): ViewMode | null {
+  if (typeof window === 'undefined') return null
+  const stored = window.localStorage.getItem(VIEW_STORAGE_KEY)
+  return stored && VALID_VIEWS.includes(stored as ViewMode)
+    ? (stored as ViewMode)
+    : null
+}
 
 export function useFileFilters(
   options: {
@@ -18,16 +30,27 @@ export function useFileFilters(
   const router = useRouter()
   const defaultLimit = options.defaultLimit || 24
 
-  const [filters, setFilters] = useState<FileFilterOptions>({
-    search: searchParams.get('search') || '',
-    types: searchParams.get('types')?.split(',').filter(Boolean) || [],
-    dateFrom: searchParams.get('dateFrom'),
-    dateTo: searchParams.get('dateTo'),
-    visibility:
-      searchParams.get('visibility')?.split(',').filter(Boolean) || [],
-    sortBy: (searchParams.get('sortBy') as SortOption) || 'newest',
-    page: parseInt(searchParams.get('page') || '1'),
-    limit: parseInt(searchParams.get('limit') || defaultLimit.toString()),
+  const [filters, setFilters] = useState<FileFilterOptions>(() => {
+    const viewParam = searchParams.get('view') as ViewMode | null
+    const initialView =
+      viewParam && VALID_VIEWS.includes(viewParam)
+        ? viewParam
+        : readStoredView() || 'grid'
+
+    return {
+      search: searchParams.get('search') || '',
+      types: searchParams.get('types')?.split(',').filter(Boolean) || [],
+      dateFrom: searchParams.get('dateFrom'),
+      dateTo: searchParams.get('dateTo'),
+      visibility:
+        searchParams.get('visibility')?.split(',').filter(Boolean) || [],
+      sortBy: (searchParams.get('sortBy') as SortOption) || 'newest',
+      page: parseInt(searchParams.get('page') || '1'),
+      limit: parseInt(searchParams.get('limit') || defaultLimit.toString()),
+      folderId: searchParams.get('folderId'),
+      tags: searchParams.get('tags')?.split(',').filter(Boolean) || [],
+      viewMode: initialView,
+    }
   })
 
   useEffect(() => {
@@ -43,6 +66,13 @@ export function useFileFilters(
     if (filters.page !== 1) params.set('page', filters.page.toString())
     if (filters.limit !== defaultLimit)
       params.set('limit', filters.limit.toString())
+    if (filters.folderId) params.set('folderId', filters.folderId)
+    if (filters.tags.length) params.set('tags', filters.tags.join(','))
+    if (filters.viewMode !== 'grid') params.set('view', filters.viewMode)
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(VIEW_STORAGE_KEY, filters.viewMode)
+    }
 
     const newParamsString = params.toString()
     const currentParamsString = new URLSearchParams(
@@ -92,8 +122,20 @@ export function useFileFilters(
     setFilters((prev) => ({ ...prev, limit, page: 1 }))
   }, [])
 
+  const setFolderId = useCallback((folderId: string | null) => {
+    setFilters((prev) => ({ ...prev, folderId, page: 1 }))
+  }, [])
+
+  const setTags = useCallback((tags: string[]) => {
+    setFilters((prev) => ({ ...prev, tags, page: 1 }))
+  }, [])
+
+  const setViewMode = useCallback((viewMode: ViewMode) => {
+    setFilters((prev) => ({ ...prev, viewMode }))
+  }, [])
+
   const resetFilters = useCallback(() => {
-    setFilters({
+    setFilters((prev) => ({
       search: '',
       types: [],
       dateFrom: null,
@@ -102,7 +144,10 @@ export function useFileFilters(
       sortBy: 'newest' as SortOption,
       page: 1,
       limit: defaultLimit,
-    })
+      folderId: null,
+      tags: [],
+      viewMode: prev.viewMode,
+    }))
   }, [defaultLimit])
 
   return {
@@ -114,6 +159,9 @@ export function useFileFilters(
     setSortBy,
     setPage,
     setLimit,
+    setFolderId,
+    setTags,
+    setViewMode,
     resetFilters,
   }
 }

--- a/hooks/use-file-selection.ts
+++ b/hooks/use-file-selection.ts
@@ -1,0 +1,66 @@
+import { useCallback, useMemo, useState } from 'react'
+
+/**
+ * Tracks a set of selected file ids for multi-select bulk operations on the
+ * dashboard.
+ */
+export function useFileSelection() {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+  const toggle = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }, [])
+
+  const select = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      if (prev.has(id)) return prev
+      const next = new Set(prev)
+      next.add(id)
+      return next
+    })
+  }, [])
+
+  const deselect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      if (!prev.has(id)) return prev
+      const next = new Set(prev)
+      next.delete(id)
+      return next
+    })
+  }, [])
+
+  const selectMany = useCallback((ids: string[]) => {
+    setSelectedIds(new Set(ids))
+  }, [])
+
+  const clear = useCallback(() => {
+    setSelectedIds((prev) => (prev.size === 0 ? prev : new Set()))
+  }, [])
+
+  const isSelected = useCallback(
+    (id: string) => selectedIds.has(id),
+    [selectedIds]
+  )
+
+  const selectedArray = useMemo(() => Array.from(selectedIds), [selectedIds])
+
+  return {
+    selectedIds,
+    selectedArray,
+    count: selectedIds.size,
+    toggle,
+    select,
+    deselect,
+    selectMany,
+    clear,
+    isSelected,
+  }
+}

--- a/hooks/use-file-upload.tsx
+++ b/hooks/use-file-upload.tsx
@@ -25,6 +25,8 @@ export type FileUploadOptions = {
   visibility?: 'PUBLIC' | 'PRIVATE'
   password?: string
   expiresAt?: Date | null
+  folderId?: string | null
+  tags?: string[]
   onUploadComplete?: (responses: UploadResponse[]) => void
   onUploadError?: (error: string) => void
 }
@@ -41,6 +43,10 @@ export function useFileUpload(options: FileUploadOptions = {}) {
   const [expiresAt, setExpiresAt] = useState<Date | null>(
     options.expiresAt || null
   )
+  const [folderId, setFolderId] = useState<string | null>(
+    options.folderId ?? null
+  )
+  const [tags, setTags] = useState<string[]>(options.tags ?? [])
   const progressToastRef = React.useRef<ReturnType<typeof toast> | null>(null)
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
@@ -238,6 +244,8 @@ export function useFileUpload(options: FileUploadOptions = {}) {
             visibility,
             password: password || null,
             expiresAt: expiresAt?.toISOString() || null,
+            folderId,
+            tags,
           }),
         }
       )
@@ -260,6 +268,8 @@ export function useFileUpload(options: FileUploadOptions = {}) {
     formData.append('visibility', visibility)
     if (password) formData.append('password', password)
     if (expiresAt) formData.append('expiresAt', expiresAt.toISOString())
+    if (folderId) formData.append('folderId', folderId)
+    if (tags.length > 0) formData.append('tags', tags.join(','))
 
     const xhr = new XMLHttpRequest()
     return await new Promise<UploadResponse>((resolve, reject) => {
@@ -417,5 +427,9 @@ export function useFileUpload(options: FileUploadOptions = {}) {
     setPassword,
     expiresAt,
     setExpiresAt,
+    folderId,
+    setFolderId,
+    tags,
+    setTags,
   }
 }

--- a/hooks/use-folders.ts
+++ b/hooks/use-folders.ts
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import type { Folder, FolderTreeNode } from '@/types/components/folder'
+import type { OrganizationColor } from '@/types/dto/folder'
+
+import { buildFolderTree } from '@/lib/folders/tree'
+
+import { useToast } from '@/hooks/use-toast'
+
+interface UseFoldersOptions {
+  enabled?: boolean
+}
+
+async function parseError(response: Response): Promise<string> {
+  try {
+    const data = await response.json()
+    return data.error || 'Something went wrong'
+  } catch {
+    return 'Something went wrong'
+  }
+}
+
+export function useFolders({ enabled = true }: UseFoldersOptions = {}) {
+  const { toast } = useToast()
+  const [folders, setFolders] = useState<Folder[]>([])
+  const [isLoading, setIsLoading] = useState(enabled)
+
+  const tree: FolderTreeNode[] = useMemo(
+    () => buildFolderTree(folders),
+    [folders]
+  )
+
+  const fetchFolders = useCallback(async () => {
+    if (!enabled) return
+    try {
+      setIsLoading(true)
+      const response = await fetch('/api/folders')
+      if (!response.ok) {
+        if (response.status === 404) {
+          setFolders([])
+          return
+        }
+        throw new Error('Failed to fetch folders')
+      }
+      const result = await response.json()
+      setFolders(result.data?.folders || [])
+    } catch (error) {
+      console.error('Error fetching folders:', error)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    fetchFolders()
+  }, [fetchFolders])
+
+  const createFolder = useCallback(
+    async (input: {
+      name: string
+      parentId?: string | null
+      color?: OrganizationColor | null
+    }): Promise<Folder | null> => {
+      try {
+        const response = await fetch('/api/folders', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        })
+        if (!response.ok) {
+          toast({
+            title: 'Failed to create folder',
+            description: await parseError(response),
+            variant: 'destructive',
+          })
+          return null
+        }
+        const result = await response.json()
+        await fetchFolders()
+        toast({ title: 'Folder created' })
+        return result.data as Folder
+      } catch {
+        toast({ title: 'Failed to create folder', variant: 'destructive' })
+        return null
+      }
+    },
+    [fetchFolders, toast]
+  )
+
+  const updateFolder = useCallback(
+    async (
+      id: string,
+      input: {
+        name?: string
+        parentId?: string | null
+        color?: OrganizationColor | null
+      }
+    ): Promise<boolean> => {
+      try {
+        const response = await fetch(`/api/folders/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        })
+        if (!response.ok) {
+          toast({
+            title: 'Failed to update folder',
+            description: await parseError(response),
+            variant: 'destructive',
+          })
+          return false
+        }
+        await fetchFolders()
+        return true
+      } catch {
+        toast({ title: 'Failed to update folder', variant: 'destructive' })
+        return false
+      }
+    },
+    [fetchFolders, toast]
+  )
+
+  const deleteFolder = useCallback(
+    async (id: string): Promise<boolean> => {
+      try {
+        const response = await fetch(`/api/folders/${id}`, {
+          method: 'DELETE',
+        })
+        if (!response.ok) {
+          toast({
+            title: 'Failed to delete folder',
+            description: await parseError(response),
+            variant: 'destructive',
+          })
+          return false
+        }
+        await fetchFolders()
+        toast({
+          title: 'Folder deleted',
+          description: 'Files in this folder were kept and moved up a level.',
+        })
+        return true
+      } catch {
+        toast({ title: 'Failed to delete folder', variant: 'destructive' })
+        return false
+      }
+    },
+    [fetchFolders, toast]
+  )
+
+  return {
+    folders,
+    tree,
+    isLoading,
+    refetch: fetchFolders,
+    createFolder,
+    updateFolder,
+    deleteFolder,
+  }
+}

--- a/hooks/use-tags.ts
+++ b/hooks/use-tags.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type { Tag } from '@/types/components/tag'
+import type { OrganizationColor } from '@/types/dto/folder'
+
+import { useToast } from '@/hooks/use-toast'
+
+interface UseTagsOptions {
+  enabled?: boolean
+}
+
+async function parseError(response: Response): Promise<string> {
+  try {
+    const data = await response.json()
+    return data.error || 'Something went wrong'
+  } catch {
+    return 'Something went wrong'
+  }
+}
+
+export function useTags({ enabled = true }: UseTagsOptions = {}) {
+  const { toast } = useToast()
+  const [tags, setTags] = useState<Tag[]>([])
+  const [isLoading, setIsLoading] = useState(enabled)
+
+  const fetchTags = useCallback(async () => {
+    if (!enabled) return
+    try {
+      setIsLoading(true)
+      const response = await fetch('/api/tags')
+      if (!response.ok) {
+        if (response.status === 404) {
+          setTags([])
+          return
+        }
+        throw new Error('Failed to fetch tags')
+      }
+      const result = await response.json()
+      setTags(result.data?.tags || [])
+    } catch (error) {
+      console.error('Error fetching tags:', error)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    fetchTags()
+  }, [fetchTags])
+
+  const createTag = useCallback(
+    async (input: {
+      name: string
+      color?: OrganizationColor | null
+    }): Promise<Tag | null> => {
+      try {
+        const response = await fetch('/api/tags', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        })
+        if (!response.ok) {
+          toast({
+            title: 'Failed to create tag',
+            description: await parseError(response),
+            variant: 'destructive',
+          })
+          return null
+        }
+        const result = await response.json()
+        await fetchTags()
+        return result.data as Tag
+      } catch {
+        toast({ title: 'Failed to create tag', variant: 'destructive' })
+        return null
+      }
+    },
+    [fetchTags, toast]
+  )
+
+  const updateTag = useCallback(
+    async (
+      id: string,
+      input: { name?: string; color?: OrganizationColor | null }
+    ): Promise<boolean> => {
+      try {
+        const response = await fetch(`/api/tags/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        })
+        if (!response.ok) {
+          toast({
+            title: 'Failed to update tag',
+            description: await parseError(response),
+            variant: 'destructive',
+          })
+          return false
+        }
+        await fetchTags()
+        return true
+      } catch {
+        toast({ title: 'Failed to update tag', variant: 'destructive' })
+        return false
+      }
+    },
+    [fetchTags, toast]
+  )
+
+  const deleteTag = useCallback(
+    async (id: string): Promise<boolean> => {
+      try {
+        const response = await fetch(`/api/tags/${id}`, { method: 'DELETE' })
+        if (!response.ok) {
+          toast({
+            title: 'Failed to delete tag',
+            description: await parseError(response),
+            variant: 'destructive',
+          })
+          return false
+        }
+        await fetchTags()
+        toast({ title: 'Tag deleted' })
+        return true
+      } catch {
+        toast({ title: 'Failed to delete tag', variant: 'destructive' })
+        return false
+      }
+    },
+    [fetchTags, toast]
+  )
+
+  return {
+    tags,
+    isLoading,
+    refetch: fetchTags,
+    createTag,
+    updateTag,
+    deleteTag,
+  }
+}

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -62,6 +62,11 @@ export const configSchema = z.object({
       ocr: z.object({
         enabled: z.boolean().default(true),
       }),
+      organization: z
+        .object({
+          enabled: z.boolean().default(true),
+        })
+        .default({ enabled: true }),
     }),
     appearance: z.object({
       theme: z.string(),
@@ -115,6 +120,9 @@ export const DEFAULT_CONFIG: FlareConfig = {
         showFooter: true,
       },
       ocr: {
+        enabled: true,
+      },
+      organization: {
         enabled: true,
       },
     },
@@ -240,6 +248,10 @@ export async function updateConfig(
           ocr: {
             ...currentConfig.settings.general.ocr,
             ...(newConfig.settings?.general?.ocr || {}),
+          },
+          organization: {
+            ...currentConfig.settings.general.organization,
+            ...(newConfig.settings?.general?.organization || {}),
           },
         },
         appearance: {

--- a/lib/files/query.ts
+++ b/lib/files/query.ts
@@ -1,0 +1,122 @@
+import type { Prisma } from '@prisma/client'
+
+export interface FileQueryParams {
+  search?: string
+  types?: string[]
+  dateFrom?: string | null
+  dateTo?: string | null
+  visibility?: string[]
+  // A folder id, the literal 'none' for unfiled files, or undefined for all.
+  folderId?: string
+  // Tag ids. A file must carry every selected tag (AND semantics).
+  tags?: string[]
+}
+
+/**
+ * Builds the Prisma `where` clause for a user's file listing from the raw query
+ * parameters. Extracted from the route handler so the (non-trivial) filtering
+ * logic can be unit-tested without a database.
+ */
+export function buildFileWhere(
+  userId: string,
+  params: FileQueryParams
+): Prisma.FileWhereInput {
+  const where: Prisma.FileWhereInput = { userId }
+  const conditions: Prisma.FileWhereInput[] = []
+
+  const search = params.search?.trim()
+  if (search) {
+    conditions.push({
+      OR: [
+        { name: { contains: search, mode: 'insensitive' } },
+        { ocrText: { contains: search, mode: 'insensitive' } },
+      ],
+    })
+  }
+
+  if (params.types && params.types.length > 0) {
+    conditions.push({ mimeType: { in: params.types } })
+  }
+
+  if (params.dateFrom || params.dateTo) {
+    const dateFilter: Prisma.DateTimeFilter = {}
+    if (params.dateFrom) {
+      dateFilter.gte = new Date(params.dateFrom)
+    }
+    if (params.dateTo) {
+      const endDate = new Date(params.dateTo)
+      endDate.setHours(23, 59, 59, 999)
+      dateFilter.lte = endDate
+    }
+    conditions.push({ uploadedAt: dateFilter })
+  }
+
+  if (params.visibility && params.visibility.length > 0) {
+    const visibilityConditions: Prisma.FileWhereInput[] = []
+    for (const filter of params.visibility) {
+      if (filter === 'hasPassword') {
+        visibilityConditions.push({ password: { not: null } })
+      } else if (filter === 'public' || filter === 'private') {
+        visibilityConditions.push({
+          visibility: filter.toUpperCase() as 'PUBLIC' | 'PRIVATE',
+        })
+      }
+    }
+    if (visibilityConditions.length > 0) {
+      conditions.push({ OR: visibilityConditions })
+    }
+  }
+
+  if (params.folderId !== undefined && params.folderId !== '') {
+    if (params.folderId === 'none') {
+      conditions.push({ folderId: null })
+    } else {
+      conditions.push({ folderId: params.folderId })
+    }
+  }
+
+  if (params.tags && params.tags.length > 0) {
+    // AND semantics: the file must have a FileTag row for each selected tag.
+    for (const tagId of params.tags) {
+      conditions.push({ tags: { some: { tagId } } })
+    }
+  }
+
+  if (conditions.length > 0) {
+    where.AND = conditions
+  }
+
+  return where
+}
+
+/**
+ * Maps a sort option to a Prisma `orderBy`. Defaults to newest-first.
+ */
+export function buildFileOrderBy(
+  sortBy: string | undefined
+): Prisma.FileOrderByWithRelationInput {
+  switch (sortBy) {
+    case 'oldest':
+      return { uploadedAt: 'asc' }
+    case 'largest':
+      return { size: 'desc' }
+    case 'smallest':
+      return { size: 'asc' }
+    case 'most-viewed':
+      return { views: 'desc' }
+    case 'least-viewed':
+      return { views: 'asc' }
+    case 'most-downloaded':
+      return { downloads: 'desc' }
+    case 'least-downloaded':
+      return { downloads: 'asc' }
+    case 'name-asc':
+    case 'name':
+      return { name: 'asc' }
+    case 'name-desc':
+      return { name: 'desc' }
+    case 'newest':
+    default:
+      return { uploadedAt: 'desc' }
+  }
+}

--- a/lib/files/serialize.ts
+++ b/lib/files/serialize.ts
@@ -1,6 +1,5 @@
-import type { Prisma } from '@prisma/client'
-
 import type { FileMetadata } from '@/types/dto/file'
+import type { Prisma } from '@prisma/client'
 
 // Shared Prisma select used when returning files to the dashboard, including the
 // folder summary and tag chips.
@@ -22,7 +21,9 @@ export const fileListSelect = {
   },
 } satisfies Prisma.FileSelect
 
-type FileWithRelations = Prisma.FileGetPayload<{ select: typeof fileListSelect }>
+type FileWithRelations = Prisma.FileGetPayload<{
+  select: typeof fileListSelect
+}>
 
 /**
  * Maps a Prisma file row (selected with {@link fileListSelect}) into the

--- a/lib/files/serialize.ts
+++ b/lib/files/serialize.ts
@@ -1,0 +1,55 @@
+import type { Prisma } from '@prisma/client'
+
+import type { FileMetadata } from '@/types/dto/file'
+
+// Shared Prisma select used when returning files to the dashboard, including the
+// folder summary and tag chips.
+export const fileListSelect = {
+  id: true,
+  name: true,
+  urlPath: true,
+  mimeType: true,
+  size: true,
+  uploadedAt: true,
+  visibility: true,
+  password: true,
+  views: true,
+  downloads: true,
+  folderId: true,
+  folder: { select: { id: true, name: true } },
+  tags: {
+    select: { tag: { select: { id: true, name: true, color: true } } },
+  },
+} satisfies Prisma.FileSelect
+
+type FileWithRelations = Prisma.FileGetPayload<{ select: typeof fileListSelect }>
+
+/**
+ * Maps a Prisma file row (selected with {@link fileListSelect}) into the
+ * dashboard `FileMetadata` shape, hiding the password hash and flattening tags.
+ */
+export function serializeFile(
+  file: FileWithRelations,
+  expiresAt: Date | null
+): FileMetadata {
+  return {
+    id: file.id,
+    name: file.name,
+    urlPath: file.urlPath,
+    mimeType: file.mimeType,
+    size: file.size,
+    uploadedAt: file.uploadedAt,
+    visibility: file.visibility,
+    views: file.views,
+    downloads: file.downloads,
+    hasPassword: Boolean(file.password),
+    expiresAt,
+    folderId: file.folderId,
+    folder: file.folder ? { id: file.folder.id, name: file.folder.name } : null,
+    tags: file.tags.map((ft) => ({
+      id: ft.tag.id,
+      name: ft.tag.name,
+      color: ft.tag.color,
+    })),
+  }
+}

--- a/lib/folders/tree.ts
+++ b/lib/folders/tree.ts
@@ -1,0 +1,131 @@
+import type { FolderBreadcrumbItem, FolderDTO } from '@/types/dto/folder'
+
+interface FolderLike {
+  id: string
+  name: string
+  parentId: string | null
+  fileCount: number
+}
+
+export type FolderTreeNodeOf<T extends FolderLike> = T & {
+  children: FolderTreeNodeOf<T>[]
+  totalFileCount: number
+}
+
+/**
+ * Converts a flat list of folders into a nested tree, sorted alphabetically at
+ * each level. `totalFileCount` aggregates a folder's own files plus those of
+ * all descendants. Generic over the folder shape so it works for both server
+ * DTOs (Date timestamps) and client models (string timestamps).
+ */
+export function buildFolderTree<T extends FolderLike>(
+  folders: T[]
+): FolderTreeNodeOf<T>[] {
+  const nodes = new Map<string, FolderTreeNodeOf<T>>()
+
+  for (const folder of folders) {
+    nodes.set(folder.id, {
+      ...folder,
+      children: [],
+      totalFileCount: folder.fileCount,
+    })
+  }
+
+  const roots: FolderTreeNodeOf<T>[] = []
+
+  for (const folder of folders) {
+    const node = nodes.get(folder.id)!
+    if (folder.parentId && nodes.has(folder.parentId)) {
+      nodes.get(folder.parentId)!.children.push(node)
+    } else {
+      roots.push(node)
+    }
+  }
+
+  // Roll up descendant file counts depth-first.
+  const computeTotals = (node: FolderTreeNodeOf<T>): number => {
+    let total = node.fileCount
+    for (const child of node.children) {
+      total += computeTotals(child)
+    }
+    node.totalFileCount = total
+    return total
+  }
+  for (const root of roots) {
+    computeTotals(root)
+  }
+
+  const sortRecursive = (list: FolderTreeNodeOf<T>[]) => {
+    list.sort((a, b) => a.name.localeCompare(b.name))
+    for (const node of list) {
+      sortRecursive(node.children)
+    }
+  }
+  sortRecursive(roots)
+
+  return roots
+}
+
+// Convenience alias for the common server-side case.
+export type ServerFolderTree = FolderTreeNodeOf<FolderDTO>
+
+/**
+ * Returns the ids of every descendant of `folderId` (not including itself).
+ */
+export function getDescendantIds(
+  folders: Pick<FolderDTO, 'id' | 'parentId'>[],
+  folderId: string
+): string[] {
+  const childrenByParent = new Map<string, string[]>()
+  for (const folder of folders) {
+    if (folder.parentId) {
+      const list = childrenByParent.get(folder.parentId) ?? []
+      list.push(folder.id)
+      childrenByParent.set(folder.parentId, list)
+    }
+  }
+
+  const result: string[] = []
+  const stack = [...(childrenByParent.get(folderId) ?? [])]
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    result.push(current)
+    const children = childrenByParent.get(current)
+    if (children) stack.push(...children)
+  }
+  return result
+}
+
+/**
+ * Determines whether moving `movingId` under `newParentId` would create a cycle.
+ * Moving a folder into itself or any of its descendants is forbidden.
+ */
+export function wouldCreateCycle(
+  folders: Pick<FolderDTO, 'id' | 'parentId'>[],
+  movingId: string,
+  newParentId: string | null
+): boolean {
+  if (newParentId === null) return false
+  if (newParentId === movingId) return true
+  const descendants = getDescendantIds(folders, movingId)
+  return descendants.includes(newParentId)
+}
+
+/**
+ * Builds the breadcrumb (root → ... → folder) for a given folder id.
+ */
+export function getBreadcrumb(
+  folders: Pick<FolderDTO, 'id' | 'name' | 'parentId'>[],
+  folderId: string
+): FolderBreadcrumbItem[] {
+  const byId = new Map(folders.map((f) => [f.id, f]))
+  const trail: FolderBreadcrumbItem[] = []
+  let current = byId.get(folderId)
+  const seen = new Set<string>()
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id)
+    trail.unshift({ id: current.id, name: current.name })
+    current = current.parentId ? byId.get(current.parentId) : undefined
+  }
+  return trail
+}

--- a/lib/folders/tree.ts
+++ b/lib/folders/tree.ts
@@ -66,9 +66,6 @@ export function buildFolderTree<T extends FolderLike>(
   return roots
 }
 
-// Convenience alias for the common server-side case.
-export type ServerFolderTree = FolderTreeNodeOf<FolderDTO>
-
 /**
  * Returns the ids of every descendant of `folderId` (not including itself).
  */

--- a/lib/middleware/constants.ts
+++ b/lib/middleware/constants.ts
@@ -9,6 +9,8 @@ export const PUBLIC_PATHS = [
   '/api/setup/check',
   '/api/health',
   '/api/files',
+  '/api/folders',
+  '/api/tags',
   '/api/urls',
   '/api/storage/type',
   '/auth/login',

--- a/lib/organization/colors.ts
+++ b/lib/organization/colors.ts
@@ -15,7 +15,8 @@ interface ColorClasses {
 const COLOR_MAP: Record<OrganizationColor, ColorClasses> = {
   slate: {
     dot: 'bg-slate-400',
-    badge: 'bg-slate-500/15 text-slate-600 dark:text-slate-300 border-slate-500/30',
+    badge:
+      'bg-slate-500/15 text-slate-600 dark:text-slate-300 border-slate-500/30',
     icon: 'text-slate-400',
   },
   red: {
@@ -77,7 +78,9 @@ const DEFAULT_CLASSES: ColorClasses = {
 }
 
 function isOrganizationColor(value: string | null): value is OrganizationColor {
-  return value !== null && (ORGANIZATION_COLORS as readonly string[]).includes(value)
+  return (
+    value !== null && (ORGANIZATION_COLORS as readonly string[]).includes(value)
+  )
 }
 
 export function getColorClasses(color: string | null): ColorClasses {

--- a/lib/organization/colors.ts
+++ b/lib/organization/colors.ts
@@ -1,0 +1,91 @@
+import { ORGANIZATION_COLORS } from '@/types/dto/folder'
+import type { OrganizationColor } from '@/types/dto/folder'
+
+// Static Tailwind class strings per color token. They must be written out in
+// full (no dynamic interpolation) so Tailwind's JIT can detect them.
+interface ColorClasses {
+  // Solid swatch (color picker dots, folder icon accents).
+  dot: string
+  // Soft pill used for tag badges.
+  badge: string
+  // Subtle text accent used for folder icons in lists/sidebar.
+  icon: string
+}
+
+const COLOR_MAP: Record<OrganizationColor, ColorClasses> = {
+  slate: {
+    dot: 'bg-slate-400',
+    badge: 'bg-slate-500/15 text-slate-600 dark:text-slate-300 border-slate-500/30',
+    icon: 'text-slate-400',
+  },
+  red: {
+    dot: 'bg-red-500',
+    badge: 'bg-red-500/15 text-red-600 dark:text-red-400 border-red-500/30',
+    icon: 'text-red-500',
+  },
+  orange: {
+    dot: 'bg-orange-500',
+    badge:
+      'bg-orange-500/15 text-orange-600 dark:text-orange-400 border-orange-500/30',
+    icon: 'text-orange-500',
+  },
+  amber: {
+    dot: 'bg-amber-500',
+    badge:
+      'bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/30',
+    icon: 'text-amber-500',
+  },
+  green: {
+    dot: 'bg-green-500',
+    badge:
+      'bg-green-500/15 text-green-600 dark:text-green-400 border-green-500/30',
+    icon: 'text-green-500',
+  },
+  teal: {
+    dot: 'bg-teal-500',
+    badge: 'bg-teal-500/15 text-teal-600 dark:text-teal-400 border-teal-500/30',
+    icon: 'text-teal-500',
+  },
+  blue: {
+    dot: 'bg-blue-500',
+    badge: 'bg-blue-500/15 text-blue-600 dark:text-blue-400 border-blue-500/30',
+    icon: 'text-blue-500',
+  },
+  indigo: {
+    dot: 'bg-indigo-500',
+    badge:
+      'bg-indigo-500/15 text-indigo-600 dark:text-indigo-400 border-indigo-500/30',
+    icon: 'text-indigo-500',
+  },
+  violet: {
+    dot: 'bg-violet-500',
+    badge:
+      'bg-violet-500/15 text-violet-600 dark:text-violet-400 border-violet-500/30',
+    icon: 'text-violet-500',
+  },
+  pink: {
+    dot: 'bg-pink-500',
+    badge: 'bg-pink-500/15 text-pink-600 dark:text-pink-400 border-pink-500/30',
+    icon: 'text-pink-500',
+  },
+}
+
+const DEFAULT_CLASSES: ColorClasses = {
+  dot: 'bg-muted-foreground/40',
+  badge: 'bg-muted text-muted-foreground border-border',
+  icon: 'text-muted-foreground',
+}
+
+function isOrganizationColor(value: string | null): value is OrganizationColor {
+  return value !== null && (ORGANIZATION_COLORS as readonly string[]).includes(value)
+}
+
+export function getColorClasses(color: string | null): ColorClasses {
+  if (isOrganizationColor(color)) {
+    return COLOR_MAP[color]
+  }
+  return DEFAULT_CLASSES
+}
+
+export { ORGANIZATION_COLORS }
+export type { OrganizationColor }

--- a/lib/organization/index.ts
+++ b/lib/organization/index.ts
@@ -1,0 +1,11 @@
+import { getConfig } from '@/lib/config'
+
+/**
+ * Whether the instance-wide organization feature (folders & tags) is enabled.
+ * When disabled, all organization APIs and UI are hidden so Flare behaves as a
+ * pure screenshot host.
+ */
+export async function isOrganizationEnabled(): Promise<boolean> {
+  const config = await getConfig()
+  return config.settings.general.organization.enabled
+}

--- a/lib/organization/upload.ts
+++ b/lib/organization/upload.ts
@@ -47,9 +47,7 @@ export async function resolveUploadOrganization(
       select: { id: true, name: true },
     })
     const byId = new Map(existingTags.map((t) => [t.id, t]))
-    const byName = new Map(
-      existingTags.map((t) => [t.name.toLowerCase(), t])
-    )
+    const byName = new Map(existingTags.map((t) => [t.name.toLowerCase(), t]))
 
     for (const token of tokens) {
       if (byId.has(token)) {

--- a/lib/organization/upload.ts
+++ b/lib/organization/upload.ts
@@ -1,0 +1,77 @@
+import { prisma } from '@/lib/database/prisma'
+import { isOrganizationEnabled } from '@/lib/organization'
+import { normalizeTagName } from '@/lib/tags/normalize'
+
+export interface ResolvedUploadOrganization {
+  folderId: string | null
+  tagIds: string[]
+}
+
+/**
+ * Resolves the optional `folderId` and `tags` supplied at upload time into a
+ * validated folder id and a set of tag ids owned by the user.
+ *
+ * - When organization is disabled instance-wide, both are ignored.
+ * - An invalid/foreign folder id is ignored (the upload still succeeds, unfiled)
+ *   so scripted uploads (e.g. ShareX) never fail on a stale folder reference.
+ * - Each tag token is matched to an existing tag by id or (case-insensitive)
+ *   name; unknown names are created on the fly. This lets clients pass either
+ *   tag ids or human-friendly names.
+ */
+export async function resolveUploadOrganization(
+  userId: string,
+  rawFolderId: string | null | undefined,
+  rawTags: string[] | undefined
+): Promise<ResolvedUploadOrganization> {
+  if (!(await isOrganizationEnabled())) {
+    return { folderId: null, tagIds: [] }
+  }
+
+  let folderId: string | null = null
+  if (rawFolderId) {
+    const folder = await prisma.folder.findFirst({
+      where: { id: rawFolderId, userId },
+      select: { id: true },
+    })
+    folderId = folder?.id ?? null
+  }
+
+  const tagIds: string[] = []
+  const tokens = (rawTags ?? [])
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+
+  if (tokens.length > 0) {
+    const existingTags = await prisma.tag.findMany({
+      where: { userId },
+      select: { id: true, name: true },
+    })
+    const byId = new Map(existingTags.map((t) => [t.id, t]))
+    const byName = new Map(
+      existingTags.map((t) => [t.name.toLowerCase(), t])
+    )
+
+    for (const token of tokens) {
+      if (byId.has(token)) {
+        if (!tagIds.includes(token)) tagIds.push(token)
+        continue
+      }
+      const name = normalizeTagName(token)
+      if (!name) continue
+      const existing = byName.get(name.toLowerCase())
+      if (existing) {
+        if (!tagIds.includes(existing.id)) tagIds.push(existing.id)
+        continue
+      }
+      const created = await prisma.tag.create({
+        data: { name, userId },
+        select: { id: true, name: true },
+      })
+      byId.set(created.id, created)
+      byName.set(created.name.toLowerCase(), created)
+      tagIds.push(created.id)
+    }
+  }
+
+  return { folderId, tagIds }
+}

--- a/lib/tags/normalize.ts
+++ b/lib/tags/normalize.ts
@@ -1,0 +1,17 @@
+import { TAG_NAME_MAX_LENGTH } from '@/types/dto/tag'
+
+/**
+ * Normalizes a raw tag name: trims, collapses internal whitespace, and clamps to
+ * the maximum length. The display casing is preserved.
+ */
+export function normalizeTagName(raw: string): string {
+  return raw.trim().replace(/\s+/g, ' ').slice(0, TAG_NAME_MAX_LENGTH)
+}
+
+/**
+ * Case-insensitive equality for tag names, used to detect duplicates while still
+ * letting users pick their preferred display casing.
+ */
+export function tagNamesEqual(a: string, b: string): boolean {
+  return a.localeCompare(b, undefined, { sensitivity: 'accent' }) === 0
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2073,9 +2073,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2091,9 +2088,6 @@
       "integrity": "sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2111,9 +2105,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2129,9 +2120,6 @@
       "integrity": "sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/prisma/migrations/20260621033721_add_folders_and_tags/migration.sql
+++ b/prisma/migrations/20260621033721_add_folders_and_tags/migration.sql
@@ -1,0 +1,83 @@
+-- AlterTable
+ALTER TABLE "File" ADD COLUMN     "folderId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Folder" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT,
+    "userId" TEXT NOT NULL,
+    "parentId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Folder_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Tag" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FileTag" (
+    "fileId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FileTag_pkey" PRIMARY KEY ("fileId","tagId")
+);
+
+-- CreateIndex
+CREATE INDEX "Folder_userId_idx" ON "Folder"("userId");
+
+-- CreateIndex
+CREATE INDEX "Folder_parentId_idx" ON "Folder"("parentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Folder_userId_parentId_name_key" ON "Folder"("userId", "parentId", "name");
+
+-- CreateIndex
+CREATE INDEX "Tag_userId_idx" ON "Tag"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_userId_name_key" ON "Tag"("userId", "name");
+
+-- CreateIndex
+CREATE INDEX "FileTag_fileId_idx" ON "FileTag"("fileId");
+
+-- CreateIndex
+CREATE INDEX "FileTag_tagId_idx" ON "FileTag"("tagId");
+
+-- CreateIndex
+CREATE INDEX "File_userId_idx" ON "File"("userId");
+
+-- CreateIndex
+CREATE INDEX "File_folderId_idx" ON "File"("folderId");
+
+-- CreateIndex
+CREATE INDEX "File_userId_folderId_idx" ON "File"("userId", "folderId");
+
+-- AddForeignKey
+ALTER TABLE "File" ADD CONSTRAINT "File_folderId_fkey" FOREIGN KEY ("folderId") REFERENCES "Folder"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Folder" ADD CONSTRAINT "Folder_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Folder" ADD CONSTRAINT "Folder_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Folder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tag" ADD CONSTRAINT "Tag_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FileTag" ADD CONSTRAINT "FileTag_fileId_fkey" FOREIGN KEY ("fileId") REFERENCES "File"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FileTag" ADD CONSTRAINT "FileTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,8 @@ model User {
   shortenedUrls               ShortenedUrl[]
   defaultFileExpiration       FileExpiration @default(DISABLED)
   defaultFileExpirationAction ExpiryAction   @default(DELETE)
+  folders                     Folder[]
+  tags                        Tag[]
 }
 
 model File {
@@ -46,7 +48,57 @@ model File {
   ocrConfidence  Float?
   views          Int            @default(0)
   downloads      Int            @default(0)
+  folderId       String?
   user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  folder         Folder?        @relation(fields: [folderId], references: [id], onDelete: SetNull)
+  tags           FileTag[]
+
+  @@index([userId])
+  @@index([folderId])
+  @@index([userId, folderId])
+}
+
+model Folder {
+  id        String   @id @default(cuid())
+  name      String
+  color     String?
+  userId    String
+  parentId  String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  parent    Folder?  @relation("FolderTree", fields: [parentId], references: [id], onDelete: Cascade)
+  children  Folder[] @relation("FolderTree")
+  files     File[]
+
+  @@unique([userId, parentId, name])
+  @@index([userId])
+  @@index([parentId])
+}
+
+model Tag {
+  id        String    @id @default(cuid())
+  name      String
+  color     String?
+  userId    String
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  files     FileTag[]
+
+  @@unique([userId, name])
+  @@index([userId])
+}
+
+model FileTag {
+  fileId     String
+  tagId      String
+  assignedAt DateTime @default(now())
+  file       File     @relation(fields: [fileId], references: [id], onDelete: Cascade)
+  tag        Tag      @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([fileId, tagId])
+  @@index([fileId])
+  @@index([tagId])
 }
 
 model ShortenedUrl {

--- a/scripts/migrate-config.js
+++ b/scripts/migrate-config.js
@@ -2,7 +2,7 @@ const { PrismaClient } = require('@prisma/client')
 const prisma = new PrismaClient()
 
 const DEFAULT_CONFIG = {
-  version: '1.1.0',
+  version: '1.2.0',
   settings: {
     general: {
       setup: {
@@ -39,6 +39,9 @@ const DEFAULT_CONFIG = {
         showFooter: true,
       },
       ocr: {
+        enabled: true,
+      },
+      organization: {
         enabled: true,
       },
     },
@@ -94,19 +97,33 @@ async function migrateConfig() {
     }
 
     const currentConfig = config.value
+    let configChanged = false
+
     if (!currentConfig.settings?.general?.ocr) {
       currentConfig.settings.general.ocr = {
         enabled: true,
       }
       currentConfig.version = '1.1.0'
+      configChanged = true
+      console.log('Added OCR settings to config')
+    }
 
+    if (!currentConfig.settings?.general?.organization) {
+      currentConfig.settings.general.organization = {
+        enabled: true,
+      }
+      currentConfig.version = '1.2.0'
+      configChanged = true
+      console.log('Added organization settings to config')
+    }
+
+    if (configChanged) {
       await prisma.config.update({
         where: { key: 'flare_config' },
         data: {
           value: currentConfig,
         },
       })
-      console.log('Added OCR settings to config')
     }
 
     console.log('Config migrations completed successfully')

--- a/types/components/file.ts
+++ b/types/components/file.ts
@@ -1,3 +1,14 @@
+export interface FileTagInfo {
+  id: string
+  name: string
+  color: string | null
+}
+
+export interface FileFolderInfo {
+  id: string
+  name: string
+}
+
 export interface FileType {
   id: string
   name: string
@@ -10,6 +21,9 @@ export interface FileType {
   views: number
   downloads: number
   expiresAt?: string | null
+  folderId: string | null
+  folder: FileFolderInfo | null
+  tags: FileTagInfo[]
 }
 
 export interface PaginationInfo {
@@ -28,6 +42,10 @@ export type SortOption =
   | 'least-viewed'
   | 'most-downloaded'
   | 'least-downloaded'
+  | 'name-asc'
+  | 'name-desc'
+
+export type ViewMode = 'grid' | 'list' | 'folder'
 
 export interface FileFilterOptions {
   page: number
@@ -38,6 +56,9 @@ export interface FileFilterOptions {
   visibility: string[]
   dateFrom: string | null
   dateTo: string | null
+  folderId: string | null
+  tags: string[]
+  viewMode: ViewMode
 }
 
 export interface FileFilter {
@@ -46,4 +67,6 @@ export interface FileFilter {
   visibility: string[]
   dateFrom: string | null
   dateTo: string | null
+  folderId: string | null
+  tags: string[]
 }

--- a/types/components/folder.ts
+++ b/types/components/folder.ts
@@ -1,0 +1,19 @@
+export interface Folder {
+  id: string
+  name: string
+  color: string | null
+  parentId: string | null
+  createdAt: string
+  updatedAt: string
+  fileCount: number
+}
+
+export interface FolderTreeNode extends Folder {
+  children: FolderTreeNode[]
+  totalFileCount: number
+}
+
+export interface FolderBreadcrumbItem {
+  id: string
+  name: string
+}

--- a/types/components/tag.ts
+++ b/types/components/tag.ts
@@ -1,0 +1,7 @@
+export interface Tag {
+  id: string
+  name: string
+  color: string | null
+  createdAt: string
+  fileCount: number
+}

--- a/types/dto/file.ts
+++ b/types/dto/file.ts
@@ -8,6 +8,8 @@ export enum FileVisibility {
 export const FileUploadSchema = z.object({
   visibility: z.enum(['PUBLIC', 'PRIVATE']).optional().default('PUBLIC'),
   password: z.string().optional().nullable(),
+  folderId: z.string().optional().nullable(),
+  tags: z.array(z.string()).optional(),
 })
 
 export type FileUploadRequest = z.infer<typeof FileUploadSchema>
@@ -19,6 +21,17 @@ export const FileUploadFormDataSchema = z.object({
 })
 
 export type FileUploadFormData = z.infer<typeof FileUploadFormDataSchema>
+
+export interface FileTagSummary {
+  id: string
+  name: string
+  color: string | null
+}
+
+export interface FileFolderSummary {
+  id: string
+  name: string
+}
 
 export interface FileMetadata {
   id: string
@@ -32,6 +45,9 @@ export interface FileMetadata {
   downloads: number
   hasPassword: boolean
   expiresAt?: Date | null
+  folderId: string | null
+  folder: FileFolderSummary | null
+  tags: FileTagSummary[]
 }
 
 export interface FileUploadResponse {
@@ -52,7 +68,19 @@ export const FileListQuerySchema = z.object({
     .optional(),
   search: z.string().optional(),
   sortBy: z
-    .enum(['newest', 'oldest', 'largest', 'smallest', 'name'])
+    .enum([
+      'newest',
+      'oldest',
+      'largest',
+      'smallest',
+      'most-viewed',
+      'least-viewed',
+      'most-downloaded',
+      'least-downloaded',
+      'name-asc',
+      'name-desc',
+      'name',
+    ])
     .optional(),
   types: z
     .string()
@@ -64,9 +92,58 @@ export const FileListQuerySchema = z.object({
     .string()
     .transform((val) => val.split(','))
     .optional(),
+  // `folderId` may be a folder id, the literal 'none' (unfiled files only), or
+  // absent (files across all folders).
+  folderId: z.string().optional(),
+  tags: z
+    .string()
+    .transform((val) => val.split(','))
+    .optional(),
 })
 
 export type FileListQuery = z.infer<typeof FileListQuerySchema>
+
+export const BulkFileActionSchema = z
+  .object({
+    fileIds: z.array(z.string().cuid()).min(1, 'No files selected'),
+    action: z.enum(['move', 'addTags', 'removeTags', 'delete']),
+    folderId: z.string().nullable().optional(),
+    tagIds: z.array(z.string().cuid()).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      (data.action === 'addTags' || data.action === 'removeTags') &&
+      (!data.tagIds || data.tagIds.length === 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'tagIds is required for tag actions',
+        path: ['tagIds'],
+      })
+    }
+  })
+
+export type BulkFileActionRequest = z.infer<typeof BulkFileActionSchema>
+
+export const UpdateFileSchema = z
+  .object({
+    visibility: z.enum(['PUBLIC', 'PRIVATE']).optional(),
+    password: z.string().nullable().optional(),
+    // `null` removes the file from any folder.
+    folderId: z.string().nullable().optional(),
+    // Full replacement of the file's tags when provided.
+    tagIds: z.array(z.string().cuid()).optional(),
+  })
+  .refine(
+    (data) =>
+      data.visibility !== undefined ||
+      data.password !== undefined ||
+      data.folderId !== undefined ||
+      data.tagIds !== undefined,
+    { message: 'No file fields provided to update' }
+  )
+
+export type UpdateFileRequest = z.infer<typeof UpdateFileSchema>
 
 export interface FileListResponse {
   files: FileMetadata[]

--- a/types/dto/folder.ts
+++ b/types/dto/folder.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod'
+
+// A small, theme-friendly palette of accent colors that folders and tags can
+// use. Kept as a closed set so the UI can render consistent swatches and we can
+// validate input server-side.
+export const ORGANIZATION_COLORS = [
+  'slate',
+  'red',
+  'orange',
+  'amber',
+  'green',
+  'teal',
+  'blue',
+  'indigo',
+  'violet',
+  'pink',
+] as const
+
+export type OrganizationColor = (typeof ORGANIZATION_COLORS)[number]
+
+export const FOLDER_NAME_MAX_LENGTH = 60
+
+const folderNameSchema = z
+  .string()
+  .trim()
+  .min(1, 'Folder name is required')
+  .max(FOLDER_NAME_MAX_LENGTH, 'Folder name is too long')
+
+const colorSchema = z.enum(ORGANIZATION_COLORS).nullable().optional()
+
+export const CreateFolderSchema = z.object({
+  name: folderNameSchema,
+  parentId: z.string().cuid().nullable().optional(),
+  color: colorSchema,
+})
+
+export type CreateFolderRequest = z.infer<typeof CreateFolderSchema>
+
+export const UpdateFolderSchema = z
+  .object({
+    name: folderNameSchema.optional(),
+    // `null` moves the folder to the root level.
+    parentId: z.string().cuid().nullable().optional(),
+    color: colorSchema,
+  })
+  .refine(
+    (data) =>
+      data.name !== undefined ||
+      data.parentId !== undefined ||
+      data.color !== undefined,
+    { message: 'No folder fields provided to update' }
+  )
+
+export type UpdateFolderRequest = z.infer<typeof UpdateFolderSchema>
+
+export interface FolderDTO {
+  id: string
+  name: string
+  color: string | null
+  parentId: string | null
+  createdAt: Date
+  updatedAt: Date
+  fileCount: number
+}
+
+export interface FolderTreeNode extends FolderDTO {
+  children: FolderTreeNode[]
+  // Total files in this folder and all descendants.
+  totalFileCount: number
+}
+
+export interface FolderBreadcrumbItem {
+  id: string
+  name: string
+}

--- a/types/dto/tag.ts
+++ b/types/dto/tag.ts
@@ -1,6 +1,5 @@
-import { z } from 'zod'
-
 import { ORGANIZATION_COLORS } from '@/types/dto/folder'
+import { z } from 'zod'
 
 export const TAG_NAME_MAX_LENGTH = 40
 

--- a/types/dto/tag.ts
+++ b/types/dto/tag.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+import { ORGANIZATION_COLORS } from '@/types/dto/folder'
+
+export const TAG_NAME_MAX_LENGTH = 40
+
+const tagNameSchema = z
+  .string()
+  .trim()
+  .min(1, 'Tag name is required')
+  .max(TAG_NAME_MAX_LENGTH, 'Tag name is too long')
+
+const colorSchema = z.enum(ORGANIZATION_COLORS).nullable().optional()
+
+export const CreateTagSchema = z.object({
+  name: tagNameSchema,
+  color: colorSchema,
+})
+
+export type CreateTagRequest = z.infer<typeof CreateTagSchema>
+
+export const UpdateTagSchema = z
+  .object({
+    name: tagNameSchema.optional(),
+    color: colorSchema,
+  })
+  .refine((data) => data.name !== undefined || data.color !== undefined, {
+    message: 'No tag fields provided to update',
+  })
+
+export type UpdateTagRequest = z.infer<typeof UpdateTagSchema>
+
+export interface TagDTO {
+  id: string
+  name: string
+  color: string | null
+  createdAt: Date
+  fileCount: number
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does your PR do?

Adds a full, opt-in **file organization** system to Flare — closes #126.

- **Folders** (nestable) and **Tags** (many-to-many, colored) for uploads
- Three dashboard **views**: Grid, List, and a Folder browser (sidebar tree + breadcrumbs)
- **Filter & sort** by folder and tag (plus the existing type/visibility/date/sort)
- **Multi-select bulk actions**: move, tag, download, delete
- Assign a **folder + tags at upload time** (direct and chunked uploads)
- **Export** now mirrors your folder structure and includes folders/tags in `user-data.json`
- An admin **master switch** (`organization.enabled`, default on) — when off, Flare behaves exactly like today

## 🎥 Demo

A ~90s captioned walkthrough of all the new UI and functionality (no need to run it locally):

[folders-tags-demo.mp4](https://cursor.com/agents/bc-0e3c36d4-7727-4a85-9393-09dfd6d3f708/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffolders-tags-demo.mp4)

## Why are you making these changes?

#126 has been on the roadmap as one of the next big features. The goal was to add organization **tastefully**: screenshot hosting stays the default, uncluttered experience, while power users who want structure get folders, tags, and richer ways to view their files. With no folders/tags created (or the toggle off), the dashboard is identical to before.

## How did you implement it?

**Storage-agnostic by design:** folders and tags are pure **database metadata**. Files still live at `uploads/{urlId}/{name}` — moving a file between folders is a single column update, so behavior is identical on local and S3 and no bytes are ever moved.

- **Schema** (`prisma/migrations/.../add_folders_and_tags`): new `Folder` (self-referential tree), `Tag`, and `FileTag` join table; `File.folderId` (nullable, `ON DELETE SET NULL`). Additive-only migration.
- **Safe deletes:** deleting a folder reparents its child folders and files up one level — **files are never deleted**. Deleting a tag only removes the label.
- **API:** `GET/POST /api/folders`, `GET/PATCH/DELETE /api/folders/[id]` (rename/recolor/move with cycle-prevention + case-insensitive name uniqueness), `GET/POST /api/tags`, `PATCH/DELETE /api/tags/[id]`, `POST /api/files/bulk` (move/addTags/removeTags/delete), and extensions to file list/`PATCH`/upload/chunked-complete/export.
- **Testable core extracted to `lib/`:** `lib/files/query.ts` (filter/sort builder), `lib/folders/tree.ts` (tree build, descendant/cycle/breadcrumb), `lib/tags/normalize.ts` — all unit-tested (47 new tests).
- **Config:** new `settings.general.organization.enabled` with schema/defaults/merge + `migrate-config.js` backfill; surfaced in admin Settings and passed to the dashboard/upload pages via server components (never exposes the admin settings API to regular users).
- **UI:** view switcher, list view, folder sidebar/breadcrumb/cards, create/rename/move dialogs, color picker, tag badge/picker/filter/manage dialog, bulk-actions bar, and additions to the file card & upload form — all using existing shadcn/ui primitives and the Flare glass design language (no new runtime deps).

## How it was tested

- `vitest`: **89 passing** (47 new unit tests for the query builder, folder tree/cycle logic, tag normalization, and DTO schemas).
- **Storage provider contract** (local + in-memory S3) still green — proves the storage layer is untouched.
- **Live end-to-end against real Postgres on both providers** (local FS **and** S3 via MinIO):
  - direct upload (≤10 MB) and chunked upload (12 MB / 3 parts) with folder + tags
  - folder/tag filtering (incl. tag AND-semantics), bulk move/tag/delete (verified MinIO objects removed)
  - folder delete reparenting (files survive), duplicate-name 409s, move cycle-prevention 400
  - export zip layout + `user-data.json`
- `next build`, `next lint`, `tsc --noEmit`, and `prettier --check` all clean.

## Screenshots / Recordings (if UI)

See the demo video above. Stills below.

**Grid view** — tag chips + folder name on cards, view switcher and Folder/Tags filters in the toolbar:

[Grid view](https://cursor.com/agents/bc-0e3c36d4-7727-4a85-9393-09dfd6d3f708/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdashboard-grid.png)

**Folder view** — sidebar tree with counts, folder cards, and unfiled files (explorer-style):

[Folder view](https://cursor.com/agents/bc-0e3c36d4-7727-4a85-9393-09dfd6d3f708/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdashboard-folder.png)

**List view** — compact table with folder, tags, and per-row actions:

[List view](https://cursor.com/agents/bc-0e3c36d4-7727-4a85-9393-09dfd6d3f708/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdashboard-list.png)

**Upload** — optional folder + tag pickers alongside the existing options:

[Upload form](https://cursor.com/agents/bc-0e3c36d4-7727-4a85-9393-09dfd6d3f708/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fupload-form.png)

**Organization disabled** — the classic, uncluttered screenshot-host experience is fully preserved:

[Organization disabled](https://cursor.com/agents/bc-0e3c36d4-7727-4a85-9393-09dfd6d3f708/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdashboard-org-disabled.png)

## Related Issues

Closes #126

## Additional Info

- Organization is **opt-in and non-intrusive**: empty state == today's experience, and the admin toggle can hide it entirely.
- `/api/folders` and `/api/tags` are allowed through middleware (their handlers enforce auth via `requireAuth`, exactly like `/api/files`), which also enables upload-token/ShareX scripting into folders/by tag name.
- Nested folders are included; the design is isolated behind `parentId` and could be reduced to a single level if preferred.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e3c36d4-7727-4a85-9393-09dfd6d3f708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e3c36d4-7727-4a85-9393-09dfd6d3f708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional folder and tag organization across uploads, file management, and export data.
  * Introduced folder and tag views, filters, breadcrumbs, and bulk actions in the dashboard.
  * Added tag and folder management controls, including create, rename, move, and delete actions.

* **Bug Fixes**
  * Improved file listing, selection, sorting, and filtering behavior for more accurate results.
  * Strengthened validation for folder, tag, and file updates to prevent invalid changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->