### PR TITLE
feat(auth): single sign-on support with OIDC

### DIFF
--- a/__tests__/auth/oidc-config.test.ts
+++ b/__tests__/auth/oidc-config.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { isOidcProviderConfigured } from '@/lib/auth'
+import { getOidcErrorMessage } from '@/lib/auth/oidc-error-messages'
+
+const complete = {
+  enabled: true,
+  issuer: 'https://idp.example.com',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  buttonText: 'Sign in with SSO',
+}
+
+describe('isOidcProviderConfigured', () => {
+  it('is true when enabled with issuer, clientId, and clientSecret all set', () => {
+    expect(isOidcProviderConfigured(complete)).toBe(true)
+  })
+
+  it.each([
+    ['enabled', false],
+    ['issuer', ''],
+    ['clientId', ''],
+    ['clientSecret', ''],
+  ] as const)('is false when %s is missing', (field, value) => {
+    expect(isOidcProviderConfigured({ ...complete, [field]: value })).toBe(
+      false
+    )
+  })
+})
+
+describe('getOidcErrorMessage', () => {
+  const knownCodes = [
+    'OidcNoEmail',
+    'OidcAccountExists',
+    'OidcNotProvisioned',
+    'OidcEmailUnverified',
+  ] as const
+  const fallback = getOidcErrorMessage('SomeUnrecognizedCode')
+
+  it.each(knownCodes)('returns a specific message for %s', (code) => {
+    const message = getOidcErrorMessage(code)
+    expect(message).toBeTruthy()
+    expect(message).not.toBe(fallback)
+  })
+
+  it('returns distinct messages for every known error code', () => {
+    const messages = knownCodes.map(getOidcErrorMessage)
+    expect(new Set(messages).size).toBe(knownCodes.length)
+  })
+
+  it('falls back to a generic message for an unrecognized code', () => {
+    expect(fallback).toBe(
+      'Sign-in with SSO failed. Please try again or contact an admin.'
+    )
+  })
+})

--- a/__tests__/auth/oidc-resolve-user.test.ts
+++ b/__tests__/auth/oidc-resolve-user.test.ts
@@ -185,6 +185,31 @@ describe('resolveOidcUser', () => {
     )
   })
 
+  it.each([
+    { verified: true, expectDate: true },
+    { verified: false, expectDate: false },
+  ])(
+    'stamps emailVerified on auto-provisioned users iff the IdP verified it (verified=$verified)',
+    async ({ verified, expectDate }) => {
+      mocks.userFindUnique
+        .mockResolvedValueOnce(null) // oidcSubject lookup misses
+        .mockResolvedValueOnce(null) // email lookup misses
+      mocks.createUser.mockResolvedValueOnce({ ...dbUser, id: 'stamped' })
+
+      await resolveOidcUser(
+        makeProfile({ email_verified: verified }),
+        makeConfig({ autoProvision: true, requireEmailVerified: false })
+      )
+
+      const [, createUserInput] = mocks.createUser.mock.calls[0]
+      if (expectDate) {
+        expect(createUserInput.emailVerified).toBeInstanceOf(Date)
+      } else {
+        expect(createUserInput.emailVerified).toBeUndefined()
+      }
+    }
+  )
+
   it('rejects with not_provisioned when no match exists and autoProvision is disabled', async () => {
     mocks.userFindUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
 

--- a/__tests__/auth/oidc-resolve-user.test.ts
+++ b/__tests__/auth/oidc-resolve-user.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  userFindUnique: vi.fn(),
+  userUpdate: vi.fn(),
+  transaction: vi.fn(),
+  createUser: vi.fn(),
+}))
+
+vi.mock('@/lib/database/prisma', () => ({
+  prisma: {
+    user: { findUnique: mocks.userFindUnique, update: mocks.userUpdate },
+    $transaction: mocks.transaction,
+  },
+}))
+
+vi.mock('@/lib/users/create-user', () => ({
+  createUser: mocks.createUser,
+}))
+
+const { resolveOidcUser } = await import('@/lib/auth/oidc-resolve-user')
+type OidcConfig = Parameters<typeof resolveOidcUser>[1]
+type OidcProfile = Parameters<typeof resolveOidcUser>[0]
+
+function makeConfig(overrides: Partial<OidcConfig> = {}): OidcConfig {
+  return {
+    autoProvision: true,
+    allowLinking: true,
+    requireEmailVerified: true,
+    ...overrides,
+  }
+}
+
+function makeProfile(overrides: Partial<OidcProfile> = {}): OidcProfile {
+  return {
+    sub: 'idp-subject-1',
+    email: 'user@example.com',
+    email_verified: true,
+    name: 'Example User',
+    ...overrides,
+  }
+}
+
+const dbUser = {
+  id: 'existing-user-id',
+  email: 'user@example.com',
+  name: 'Existing User',
+  role: 'USER' as const,
+  image: null,
+  sessionVersion: 1,
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mocks.transaction.mockImplementation((cb: (tx: unknown) => unknown) => cb({}))
+})
+
+describe('resolveOidcUser', () => {
+  it('resolves an existing user by oidcSubject without any email checks', async () => {
+    mocks.userFindUnique.mockResolvedValueOnce(dbUser)
+
+    const result = await resolveOidcUser(
+      makeProfile({ email: undefined, email_verified: false }),
+      makeConfig({ requireEmailVerified: true })
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      user: expect.objectContaining({ id: dbUser.id }),
+    })
+    expect(mocks.userFindUnique).toHaveBeenCalledTimes(1)
+    expect(mocks.userFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { oidcSubject: 'idp-subject-1' } })
+    )
+  })
+
+  it('rejects with no_email when the provider omits an email', async () => {
+    mocks.userFindUnique.mockResolvedValueOnce(null) // oidcSubject lookup misses
+
+    const result = await resolveOidcUser(
+      makeProfile({ email: null }),
+      makeConfig()
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'no_email' })
+  })
+
+  it.each([true, false])(
+    'rejects unverified email before any email-based lookup (allowLinking=%s)',
+    async (allowLinking) => {
+      mocks.userFindUnique.mockResolvedValueOnce(null) // oidcSubject lookup misses
+
+      const result = await resolveOidcUser(
+        makeProfile({ email_verified: false }),
+        makeConfig({
+          requireEmailVerified: true,
+          allowLinking,
+          autoProvision: true,
+        })
+      )
+
+      expect(result).toEqual({ ok: false, reason: 'email_unverified' })
+      expect(mocks.userFindUnique).toHaveBeenCalledTimes(1) // only the subject lookup
+      expect(mocks.userUpdate).not.toHaveBeenCalled()
+      expect(mocks.createUser).not.toHaveBeenCalled()
+    }
+  )
+
+  it('links to an existing account when linking is allowed and email is verified', async () => {
+    const linkedUser = { ...dbUser, id: 'linked-user-id' }
+    mocks.userFindUnique
+      .mockResolvedValueOnce(null) // oidcSubject lookup misses
+      .mockResolvedValueOnce(dbUser) // email lookup hits
+    mocks.userUpdate.mockResolvedValueOnce(linkedUser)
+
+    const result = await resolveOidcUser(
+      makeProfile({ email_verified: true }),
+      makeConfig({ allowLinking: true, requireEmailVerified: true })
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      user: expect.objectContaining({ id: linkedUser.id }),
+    })
+    expect(mocks.userUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: dbUser.id },
+        data: { oidcSubject: 'idp-subject-1' },
+      })
+    )
+  })
+
+  it('links without a verified email when requireEmailVerified is disabled', async () => {
+    mocks.userFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(dbUser)
+    mocks.userUpdate.mockResolvedValueOnce(dbUser)
+
+    const result = await resolveOidcUser(
+      makeProfile({ email_verified: undefined }),
+      makeConfig({ allowLinking: true, requireEmailVerified: false })
+    )
+
+    expect(result.ok).toBe(true)
+    expect(mocks.userUpdate).toHaveBeenCalled()
+  })
+
+  it('rejects with account_exists when a match is found but linking is disabled', async () => {
+    mocks.userFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(dbUser)
+
+    const result = await resolveOidcUser(
+      makeProfile({ email_verified: true }),
+      makeConfig({ allowLinking: false })
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'account_exists' })
+    expect(mocks.userUpdate).not.toHaveBeenCalled()
+  })
+
+  it('auto-provisions a new user when no match exists, falling back to the email prefix for name', async () => {
+    const createdUser = { ...dbUser, id: 'new-user-id' }
+    mocks.userFindUnique
+      .mockResolvedValueOnce(null) // oidcSubject lookup misses
+      .mockResolvedValueOnce(null) // email lookup misses
+    mocks.createUser.mockResolvedValueOnce(createdUser)
+
+    const result = await resolveOidcUser(
+      makeProfile({ name: undefined, email: 'newperson@example.com' }),
+      makeConfig({ autoProvision: true })
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      user: expect.objectContaining({ id: createdUser.id }),
+    })
+    expect(mocks.createUser).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        email: 'newperson@example.com',
+        name: 'newperson',
+        oidcSubject: 'idp-subject-1',
+      })
+    )
+  })
+
+  it('rejects with not_provisioned when no match exists and autoProvision is disabled', async () => {
+    mocks.userFindUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+
+    const result = await resolveOidcUser(
+      makeProfile(),
+      makeConfig({ autoProvision: false })
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'not_provisioned' })
+    expect(mocks.createUser).not.toHaveBeenCalled()
+  })
+})

--- a/app/(main)/auth/login/page.tsx
+++ b/app/(main)/auth/login/page.tsx
@@ -1,14 +1,26 @@
 import { LoginForm } from '@/components/auth/login-form'
+import { OidcAutoRedirect } from '@/components/auth/oidc-auto-redirect'
 import { DynamicBackground } from '@/components/layout/dynamic-background'
 import { Icons } from '@/components/shared/icons'
 
+import { isOidcProviderConfigured } from '@/lib/auth'
 import { getConfig } from '@/lib/config'
 
 export const dynamic = 'force-dynamic'
 
-export default async function LoginPage() {
+interface LoginPageProps {
+  searchParams: Promise<{ local?: string; error?: string }>
+}
+
+export default async function LoginPage({
+  searchParams,
+}: Readonly<LoginPageProps>) {
   const config = await getConfig()
+  const { local, error } = await searchParams
   const registrationsEnabled = config.settings.general.registrations.enabled
+  const oidc = config.settings.general.oidc
+  const oidcConfigured = isOidcProviderConfigured(oidc)
+  const oidcAutoRedirect = oidcConfigured && oidc.enforceSso && local !== '1'
 
   return (
     <main className="relative min-h-[calc(100vh-57px)] overflow-hidden">
@@ -31,12 +43,21 @@ export default async function LoginPage() {
           <div className="relative rounded-2xl bg-white/10 dark:bg-black/10 backdrop-blur-xl border border-white/20 dark:border-white/10 shadow-lg shadow-black/5 dark:shadow-black/20">
             <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-white/10 via-transparent to-black/5 dark:from-white/5 dark:via-transparent dark:to-black/10" />
             <div className="relative p-8">
-              <LoginForm
-                registrationsEnabled={registrationsEnabled}
-                disabledMessage={
-                  config.settings.general.registrations.disabledMessage
-                }
-              />
+              {oidcAutoRedirect ? (
+                <OidcAutoRedirect
+                  buttonText={oidc.buttonText}
+                  errorCode={error}
+                />
+              ) : (
+                <LoginForm
+                  registrationsEnabled={registrationsEnabled}
+                  disabledMessage={
+                    config.settings.general.registrations.disabledMessage
+                  }
+                  oidcEnabled={oidcConfigured}
+                  oidcButtonText={oidc.buttonText}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/app/(main)/dashboard/settings/page.tsx
+++ b/app/(main)/dashboard/settings/page.tsx
@@ -1166,6 +1166,300 @@ export default function SettingsPage() {
 
               <Card>
                 <CardHeader>
+                  <CardTitle>Single Sign-On (OIDC)</CardTitle>
+                  <CardDescription>
+                    Let users sign in through an external OpenID Connect
+                    identity provider
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Enable OIDC Sign-In</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Enable or disable single sign-on with ODIC
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {isFieldChanged('general', ['oidc', 'enabled']) && (
+                        <ChangeIndicator />
+                      )}
+                      <Switch
+                        checked={workingConfig.settings.general.oidc.enabled}
+                        onCheckedChange={(checked) =>
+                          handleSettingChange('general', {
+                            oidc: {
+                              ...workingConfig.settings.general.oidc,
+                              enabled: checked,
+                            },
+                          })
+                        }
+                        className={getFieldClasses('general', [
+                          'oidc',
+                          'enabled',
+                        ])}
+                      />
+                    </div>
+                  </div>
+
+                  {workingConfig.settings.general.oidc.enabled && (
+                    <div className="space-y-4 border rounded-lg p-4">
+                      <div className="space-y-2">
+                        <Label>Issuer URL</Label>
+                        <div className="flex items-center gap-2">
+                          <Input
+                            value={workingConfig.settings.general.oidc.issuer}
+                            onChange={(e) =>
+                              handleSettingChange('general', {
+                                oidc: {
+                                  ...workingConfig.settings.general.oidc,
+                                  issuer: e.target.value,
+                                },
+                              })
+                            }
+                            placeholder="https://idp.example.com"
+                            className={getFieldClasses('general', [
+                              'oidc',
+                              'issuer',
+                            ])}
+                          />
+                          {isFieldChanged('general', ['oidc', 'issuer']) && (
+                            <ChangeIndicator />
+                          )}
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          Flare discovers the provider&apos;s endpoints from{' '}
+                          <code>
+                            {'{issuer}'}/.well-known/openid-configuration
+                          </code>
+                        </p>
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label>Client ID</Label>
+                        <div className="flex items-center gap-2">
+                          <Input
+                            value={workingConfig.settings.general.oidc.clientId}
+                            onChange={(e) =>
+                              handleSettingChange('general', {
+                                oidc: {
+                                  ...workingConfig.settings.general.oidc,
+                                  clientId: e.target.value,
+                                },
+                              })
+                            }
+                            className={getFieldClasses('general', [
+                              'oidc',
+                              'clientId',
+                            ])}
+                          />
+                          {isFieldChanged('general', ['oidc', 'clientId']) && (
+                            <ChangeIndicator />
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label>Client Secret</Label>
+                        <div className="flex items-center gap-2">
+                          <Input
+                            type="password"
+                            value={
+                              workingConfig.settings.general.oidc.clientSecret
+                            }
+                            onChange={(e) =>
+                              handleSettingChange('general', {
+                                oidc: {
+                                  ...workingConfig.settings.general.oidc,
+                                  clientSecret: e.target.value,
+                                },
+                              })
+                            }
+                            className={getFieldClasses('general', [
+                              'oidc',
+                              'clientSecret',
+                            ])}
+                          />
+                          {isFieldChanged('general', [
+                            'oidc',
+                            'clientSecret',
+                          ]) && <ChangeIndicator />}
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label>Sign-In Button Text</Label>
+                        <div className="flex items-center gap-2">
+                          <Input
+                            value={
+                              workingConfig.settings.general.oidc.buttonText
+                            }
+                            onChange={(e) =>
+                              handleSettingChange('general', {
+                                oidc: {
+                                  ...workingConfig.settings.general.oidc,
+                                  buttonText: e.target.value,
+                                },
+                              })
+                            }
+                            placeholder="Sign in with SSO"
+                            className={getFieldClasses('general', [
+                              'oidc',
+                              'buttonText',
+                            ])}
+                          />
+                          {isFieldChanged('general', [
+                            'oidc',
+                            'buttonText',
+                          ]) && <ChangeIndicator />}
+                        </div>
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label>Auto-Provision Users</Label>
+                          <p className="text-sm text-muted-foreground">
+                            Create a new account automatically the first time
+                            someone signs in through the provider
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {isFieldChanged('general', [
+                            'oidc',
+                            'autoProvision',
+                          ]) && <ChangeIndicator />}
+                          <Switch
+                            checked={
+                              workingConfig.settings.general.oidc.autoProvision
+                            }
+                            onCheckedChange={(checked) =>
+                              handleSettingChange('general', {
+                                oidc: {
+                                  ...workingConfig.settings.general.oidc,
+                                  autoProvision: checked,
+                                },
+                              })
+                            }
+                            className={getFieldClasses('general', [
+                              'oidc',
+                              'autoProvision',
+                            ])}
+                          />
+                        </div>
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label>Link Existing Accounts</Label>
+                          <p className="text-sm text-muted-foreground">
+                            If the provider&apos;s email matches an existing
+                            local account, sign in as that account instead of
+                            rejecting the login
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {isFieldChanged('general', [
+                            'oidc',
+                            'allowLinking',
+                          ]) && <ChangeIndicator />}
+                          <Switch
+                            checked={
+                              workingConfig.settings.general.oidc.allowLinking
+                            }
+                            onCheckedChange={(checked) =>
+                              handleSettingChange('general', {
+                                oidc: {
+                                  ...workingConfig.settings.general.oidc,
+                                  allowLinking: checked,
+                                },
+                              })
+                            }
+                            className={getFieldClasses('general', [
+                              'oidc',
+                              'allowLinking',
+                            ])}
+                          />
+                        </div>
+                      </div>
+
+                      {workingConfig.settings.general.oidc.allowLinking && (
+                        <div className="flex items-center justify-between">
+                          <div className="space-y-0.5">
+                            <Label>Require Verified Email</Label>
+                            <p className="text-sm text-muted-foreground">
+                              Only link to an existing account if the provider
+                              confirms the email is verified. Disable only if
+                              you trust all accounts that may register with your
+                              provider.
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {isFieldChanged('general', [
+                              'oidc',
+                              'requireEmailVerified',
+                            ]) && <ChangeIndicator />}
+                            <Switch
+                              checked={
+                                workingConfig.settings.general.oidc
+                                  .requireEmailVerified
+                              }
+                              onCheckedChange={(checked) =>
+                                handleSettingChange('general', {
+                                  oidc: {
+                                    ...workingConfig.settings.general.oidc,
+                                    requireEmailVerified: checked,
+                                  },
+                                })
+                              }
+                              className={getFieldClasses('general', [
+                                'oidc',
+                                'requireEmailVerified',
+                              ])}
+                            />
+                          </div>
+                        </div>
+                      )}
+
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label>OIDC Auto-login</Label>
+                          <p className="text-sm text-muted-foreground">
+                            Skip the login form and redirect straight to the
+                            provider. Visit <code>/auth/login?local=1</code> to
+                            reach the password login if you get locked out.
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {isFieldChanged('general', [
+                            'oidc',
+                            'enforceSso',
+                          ]) && <ChangeIndicator />}
+                          <Switch
+                            checked={
+                              workingConfig.settings.general.oidc.enforceSso
+                            }
+                            onCheckedChange={(checked) =>
+                              handleSettingChange('general', {
+                                oidc: {
+                                  ...workingConfig.settings.general.oidc,
+                                  enforceSso: checked,
+                                },
+                              })
+                            }
+                            className={getFieldClasses('general', [
+                              'oidc',
+                              'enforceSso',
+                            ])}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
                   <CardTitle>Credits</CardTitle>
                   <CardDescription>
                     Manage footer credits visibility

--- a/app/(main)/dashboard/settings/page.tsx
+++ b/app/(main)/dashboard/settings/page.tsx
@@ -1382,43 +1382,40 @@ export default function SettingsPage() {
                         </div>
                       </div>
 
-                      {workingConfig.settings.general.oidc.allowLinking && (
-                        <div className="flex items-center justify-between">
-                          <div className="space-y-0.5">
-                            <Label>Require Verified Email</Label>
-                            <p className="text-sm text-muted-foreground">
-                              Only link to an existing account if the provider
-                              confirms the email is verified. Disable only if
-                              you trust all accounts that may register with your
-                              provider.
-                            </p>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            {isFieldChanged('general', [
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label>Require Verified Email</Label>
+                          <p className="text-sm text-muted-foreground">
+                            Require ODIC provider to confirm user email is
+                            verified. Disable only if you trust all accounts
+                            that may register with your provider.
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {isFieldChanged('general', [
+                            'oidc',
+                            'requireEmailVerified',
+                          ]) && <ChangeIndicator />}
+                          <Switch
+                            checked={
+                              workingConfig.settings.general.oidc
+                                .requireEmailVerified
+                            }
+                            onCheckedChange={(checked) =>
+                              handleSettingChange('general', {
+                                oidc: {
+                                  ...workingConfig.settings.general.oidc,
+                                  requireEmailVerified: checked,
+                                },
+                              })
+                            }
+                            className={getFieldClasses('general', [
                               'oidc',
                               'requireEmailVerified',
-                            ]) && <ChangeIndicator />}
-                            <Switch
-                              checked={
-                                workingConfig.settings.general.oidc
-                                  .requireEmailVerified
-                              }
-                              onCheckedChange={(checked) =>
-                                handleSettingChange('general', {
-                                  oidc: {
-                                    ...workingConfig.settings.general.oidc,
-                                    requireEmailVerified: checked,
-                                  },
-                                })
-                              }
-                              className={getFieldClasses('general', [
-                                'oidc',
-                                'requireEmailVerified',
-                              ])}
-                            />
-                          </div>
+                            ])}
+                          />
                         </div>
-                      )}
+                      </div>
 
                       <div className="flex items-center justify-between">
                         <div className="space-y-0.5">

--- a/app/(main)/dashboard/settings/page.tsx
+++ b/app/(main)/dashboard/settings/page.tsx
@@ -1177,7 +1177,7 @@ export default function SettingsPage() {
                     <div className="space-y-0.5">
                       <Label>Enable OIDC Sign-In</Label>
                       <p className="text-sm text-muted-foreground">
-                        Enable or disable single sign-on with ODIC
+                        Enable or disable single sign-on with OIDC
                       </p>
                     </div>
                     <div className="flex items-center gap-2">
@@ -1386,7 +1386,7 @@ export default function SettingsPage() {
                         <div className="space-y-0.5">
                           <Label>Require Verified Email</Label>
                           <p className="text-sm text-muted-foreground">
-                            Require ODIC provider to confirm user email is
+                            Require OIDC provider to confirm user email is
                             verified. Disable only if you trust all accounts
                             that may register with your provider.
                           </p>

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,14 +1,19 @@
 import NextAuth from 'next-auth/next'
 
-import { authOptions } from '@/lib/auth'
+import { getAuthOptions } from '@/lib/auth'
 import { authLimiter, rateLimit } from '@/lib/security/rate-limit'
 
-const nextAuth = NextAuth(authOptions)
+type Handler = ReturnType<typeof NextAuth>
 
-export { nextAuth as GET }
+async function handler(...args: Parameters<Handler>) {
+  const options = await getAuthOptions()
+  return NextAuth(options)(...args)
+}
 
-export async function POST(...args: Parameters<typeof nextAuth>) {
+export { handler as GET }
+
+export async function POST(...args: Parameters<Handler>) {
   const limited = await rateLimit(args[0] as unknown as Request, authLimiter)
   if (limited) return limited
-  return nextAuth(...args)
+  return handler(...args)
 }

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,30 +1,18 @@
 import { NextResponse } from 'next/server'
 
 import { hash } from 'bcryptjs'
-import { nanoid } from 'nanoid'
-import { v4 as uuidv4 } from 'uuid'
 import { z } from 'zod'
 
 import { getConfig } from '@/lib/config'
 import { prisma } from '@/lib/database/prisma'
 import { authLimiter, rateLimit } from '@/lib/security/rate-limit'
+import { createUser } from '@/lib/users/create-user'
 
 const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
   name: z.string().min(2),
 })
-
-function generateUrlId() {
-  const alphabet = '23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-  return nanoid(5)
-    .split('')
-    .map((char) => {
-      const index = Math.floor((alphabet.length * char.charCodeAt(0)) / 256)
-      return alphabet[index]
-    })
-    .join('')
-}
 
 class RegistrationConflictError extends Error {
   constructor() {
@@ -55,31 +43,10 @@ export async function POST(req: Request) {
         throw new RegistrationConflictError()
       }
 
-      let urlId = generateUrlId()
-      let isUnique = false
-      while (!isUnique) {
-        const existing = await tx.user.findUnique({
-          where: { urlId },
-        })
-        if (!existing) {
-          isUnique = true
-        } else {
-          urlId = generateUrlId()
-        }
-      }
-
-      const userCount = await tx.user.count()
-      const isFirstUser = userCount === 0
-
-      return tx.user.create({
-        data: {
-          email: body.email,
-          name: body.name,
-          password: hashedPassword,
-          urlId,
-          role: isFirstUser ? 'ADMIN' : 'USER',
-          uploadToken: uuidv4(),
-        },
+      return createUser(tx, {
+        email: body.email,
+        name: body.name,
+        password: hashedPassword,
       })
     })
 

--- a/app/api/setup/route.ts
+++ b/app/api/setup/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server'
 
 import { hash } from 'bcryptjs'
-import { v4 as uuidv4 } from 'uuid'
 import { z } from 'zod'
 
 import { updateConfig } from '@/lib/config'
 import { prisma } from '@/lib/database/prisma'
 import { loggers } from '@/lib/logger'
 import { rateLimit, setupLimiter } from '@/lib/security/rate-limit'
+import { createUser } from '@/lib/users/create-user'
 
 const logger = loggers.startup
 
@@ -15,13 +15,6 @@ class SetupAlreadyCompleteError extends Error {
   constructor() {
     super('Setup already completed')
   }
-}
-
-function generateUrlId() {
-  const alphabet = '23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-  return Array.from({ length: 5 }, () => {
-    return alphabet.charAt(Math.floor(Math.random() * alphabet.length))
-  }).join('')
 }
 
 const setupSchema = z.object({
@@ -63,29 +56,12 @@ export async function POST(req: Request) {
         throw new SetupAlreadyCompleteError()
       }
 
-      let urlId = generateUrlId()
-      let isUnique = false
-      while (!isUnique) {
-        const existing = await tx.user.findUnique({
-          where: { urlId },
-        })
-        if (!existing) {
-          isUnique = true
-        } else {
-          urlId = generateUrlId()
-        }
-      }
-
-      return tx.user.create({
-        data: {
-          name: validatedData.admin.name,
-          email: validatedData.admin.email,
-          password: hashedPassword,
-          role: 'ADMIN',
-          emailVerified: new Date(),
-          urlId,
-          uploadToken: uuidv4(),
-        },
+      return createUser(tx, {
+        name: validatedData.admin.name,
+        email: validatedData.admin.email,
+        password: hashedPassword,
+        role: 'ADMIN',
+        emailVerified: new Date(),
       })
     })
 
@@ -120,6 +96,17 @@ export async function POST(req: Request) {
           },
           ocr: {
             enabled: true,
+          },
+          oidc: {
+            enabled: false,
+            issuer: '',
+            clientId: '',
+            clientSecret: '',
+            buttonText: 'Sign in with SSO',
+            autoProvision: true,
+            allowLinking: true,
+            requireEmailVerified: true,
+            enforceSso: false,
           },
         },
         appearance: {

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,6 +1,5 @@
 import { UserResponse, UserSchema } from '@/types/dto/user'
 import { hash } from 'bcryptjs'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   HTTP_STATUS,
@@ -12,6 +11,7 @@ import { requireAdmin } from '@/lib/auth/api-auth'
 import { prisma } from '@/lib/database/prisma'
 import { loggers } from '@/lib/logger'
 import { getStorageProvider } from '@/lib/storage'
+import { createUser } from '@/lib/users/create-user'
 
 const logger = loggers.users
 
@@ -87,54 +87,30 @@ export async function POST(req: Request) {
       return apiError('User already exists', HTTP_STATUS.BAD_REQUEST)
     }
 
-    const generateUrlId = () =>
-      Array.from({ length: 5 }, () => {
-        const chars =
-          '23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-        return chars.charAt(Math.floor(Math.random() * chars.length))
-      }).join('')
+    const hashedPassword = body.password
+      ? await hash(body.password, 10)
+      : undefined
 
-    let urlId = generateUrlId()
-    let isUnique = false
-    while (!isUnique) {
-      const existing = await prisma.user.findUnique({
-        where: { urlId },
-      })
-      if (!existing) {
-        isUnique = true
-      } else {
-        urlId = generateUrlId()
-      }
-    }
-
-    const user = await prisma.user.create({
-      data: {
+    const user = await prisma.$transaction((tx) =>
+      createUser(tx, {
         email: body.email,
         name: body.name,
-        password: body.password ? await hash(body.password, 10) : undefined,
+        password: hashedPassword,
         role: body.role,
-        urlId,
-        uploadToken: uuidv4(),
-      },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        image: true,
-        role: true,
-        urlId: true,
-        vanityId: true,
-        storageUsed: true,
-        _count: {
-          select: {
-            files: true,
-            shortenedUrls: true,
-          },
-        },
-      },
-    })
+      })
+    )
 
-    return apiResponse<UserResponse>(user)
+    return apiResponse<UserResponse>({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      image: user.image,
+      role: user.role,
+      urlId: user.urlId,
+      vanityId: user.vanityId,
+      storageUsed: user.storageUsed,
+      _count: { files: 0, shortenedUrls: 0 },
+    })
   } catch (error) {
     logger.error('Error creating user', error as Error)
     return apiError('Internal server error', HTTP_STATUS.INTERNAL_SERVER_ERROR)

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -42,7 +42,11 @@ export function LoginForm({
 
   async function onOidcSignIn() {
     setIsOidcLoading(true)
-    await signIn('oidc', { callbackUrl: '/dashboard' })
+    try {
+      await signIn('oidc', { callbackUrl: '/dashboard' })
+    } catch {
+      setIsOidcLoading(false)
+    }
   }
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 import { signIn } from 'next-auth/react'
 
@@ -12,18 +12,38 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
+import { getOidcErrorMessage } from '@/lib/auth/oidc-error-messages'
+
 interface LoginFormProps {
   registrationsEnabled: boolean
   disabledMessage: string
+  oidcEnabled?: boolean
+  oidcButtonText?: string
 }
 
 export function LoginForm({
   registrationsEnabled,
   disabledMessage,
-}: LoginFormProps) {
+  oidcEnabled = false,
+  oidcButtonText = 'Sign in with SSO',
+}: Readonly<LoginFormProps>) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [isLoading, setIsLoading] = useState(false)
+  const [isOidcLoading, setIsOidcLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const errorCode = searchParams.get('error')
+    if (errorCode) {
+      setError(getOidcErrorMessage(errorCode))
+    }
+  }, [searchParams])
+
+  async function onOidcSignIn() {
+    setIsOidcLoading(true)
+    await signIn('oidc', { callbackUrl: '/dashboard' })
+  }
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -130,6 +150,36 @@ export function LoginForm({
           )}
         </Button>
       </div>
+      {oidcEnabled && (
+        <div className="pt-6 space-y-4">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t border-white/10" />
+            </div>
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-background px-2 text-muted-foreground">
+                Or
+              </span>
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full h-11 font-medium"
+            disabled={isOidcLoading}
+            onClick={onOidcSignIn}
+          >
+            {isOidcLoading ? (
+              <>
+                <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+                Redirecting...
+              </>
+            ) : (
+              oidcButtonText
+            )}
+          </Button>
+        </div>
+      )}
     </form>
   )
 }

--- a/components/auth/oidc-auto-redirect.tsx
+++ b/components/auth/oidc-auto-redirect.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import Link from 'next/link'
+
+import { signIn } from 'next-auth/react'
+
+import { Icons } from '@/components/shared/icons'
+import { Button } from '@/components/ui/button'
+
+import { getOidcErrorMessage } from '@/lib/auth/oidc-error-messages'
+
+interface OidcAutoRedirectProps {
+  buttonText: string
+  errorCode?: string
+}
+
+function redirectToOidc() {
+  signIn('oidc', { callbackUrl: '/dashboard' })
+}
+
+export function OidcAutoRedirect({
+  buttonText,
+  errorCode,
+}: Readonly<OidcAutoRedirectProps>) {
+  useEffect(() => {
+    if (!errorCode) {
+      redirectToOidc()
+    }
+    // Only auto-fire on first mount for a given error state,
+    // or a persistently failing provider becomes a redirect loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div className="space-y-6 text-center">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {errorCode ? 'Sign-in failed' : 'Redirecting to sign-in'}
+        </h1>
+        <p className="text-base text-muted-foreground">
+          {errorCode
+            ? getOidcErrorMessage(errorCode)
+            : "Taking you to your organization's sign-in page..."}
+        </p>
+      </div>
+      <Button
+        type="button"
+        className="w-full h-11 font-medium bg-primary hover:bg-primary/90 transition-colors"
+        onClick={redirectToOidc}
+      >
+        {errorCode ? (
+          buttonText
+        ) : (
+          <>
+            <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+            {buttonText}
+          </>
+        )}
+      </Button>
+      <Link
+        href="/auth/login?local=1"
+        className="block text-xs text-muted-foreground hover:text-foreground hover:underline transition-colors"
+      >
+        Use local sign-in instead
+      </Link>
+    </div>
+  )
+}

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -108,10 +108,17 @@ export const authOptions: NextAuthOptions = {
       }
 
       const config = await getConfig()
-      const result = await resolveOidcUser(profile as OidcProfile, {
-        autoProvision: config.settings.general.oidc.autoProvision,
-        allowLinking: config.settings.general.oidc.allowLinking,
-        requireEmailVerified: config.settings.general.oidc.requireEmailVerified,
+      const oidcConfig = config.settings.general.oidc
+      const rawProfile = profile as OidcProfile
+      const scopedProfile: OidcProfile = {
+        ...rawProfile,
+        sub: scopeOidcSubject(oidcConfig.issuer, rawProfile.sub),
+      }
+
+      const result = await resolveOidcUser(scopedProfile, {
+        autoProvision: oidcConfig.autoProvision,
+        allowLinking: oidcConfig.allowLinking,
+        requireEmailVerified: oidcConfig.requireEmailVerified,
       })
 
       if (!result.ok) {
@@ -183,6 +190,14 @@ function trimTrailingSlashes(value: string) {
     end -= 1
   }
   return value.slice(0, end)
+}
+
+/**
+ * OIDC `sub` is only unique within its issuer, not globally, so it must be
+ * scoped before being used as a global lookup key (see oidcSubject on User).
+ */
+function scopeOidcSubject(issuer: string, sub: string): string {
+  return `${trimTrailingSlashes(issuer)}|${sub}`
 }
 
 interface OidcRawProfile extends Record<string, unknown> {

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -3,8 +3,12 @@ import { compare } from 'bcryptjs'
 import { NextAuthOptions, Session } from 'next-auth'
 import { JWT } from 'next-auth/jwt'
 import CredentialsProvider from 'next-auth/providers/credentials'
+import type { OAuthConfig } from 'next-auth/providers/oauth'
 
+import { getConfig } from '@/lib/config'
 import { prisma } from '@/lib/database/prisma'
+
+import { OidcProfile, resolveOidcUser } from './oidc-resolve-user'
 
 const userSelect = {
   id: true,
@@ -18,6 +22,13 @@ const userSelect = {
 
 type UserWithSession = Prisma.UserGetPayload<{ select: typeof userSelect }>
 
+const oidcErrorParams = {
+  no_email: 'OidcNoEmail',
+  account_exists: 'OidcAccountExists',
+  not_provisioned: 'OidcNotProvisioned',
+  email_unverified: 'OidcEmailUnverified',
+} as const
+
 declare module 'next-auth' {
   interface Session {
     user: {
@@ -27,6 +38,11 @@ declare module 'next-auth' {
       image: string | null
       role: UserRole
     }
+  }
+
+  interface User {
+    role?: UserRole
+    sessionVersion?: number
   }
 }
 
@@ -61,7 +77,7 @@ export const authOptions: NextAuthOptions = {
           select: userSelect,
         })
 
-        if (!user || !user.password) {
+        if (!user?.password) {
           return null
         }
 
@@ -86,6 +102,25 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
+    async signIn({ user, account, profile }) {
+      if (account?.provider !== 'oidc') {
+        return true
+      }
+
+      const config = await getConfig()
+      const result = await resolveOidcUser(profile as OidcProfile, {
+        autoProvision: config.settings.general.oidc.autoProvision,
+        allowLinking: config.settings.general.oidc.allowLinking,
+        requireEmailVerified: config.settings.general.oidc.requireEmailVerified,
+      })
+
+      if (!result.ok) {
+        return `/auth/login?error=${oidcErrorParams[result.reason]}`
+      }
+
+      Object.assign(user, result.user)
+      return true
+    },
     async jwt({ token, user }): Promise<JWT> {
       if (user) {
         const sessionUser = user as UserWithSession
@@ -140,4 +175,68 @@ export const authOptions: NextAuthOptions = {
     strategy: 'jwt',
     maxAge: 30 * 24 * 60 * 60,
   },
+}
+
+function trimTrailingSlashes(value: string) {
+  let end = value.length
+  while (end > 0 && value[end - 1] === '/') {
+    end -= 1
+  }
+  return value.slice(0, end)
+}
+
+interface OidcRawProfile extends Record<string, unknown> {
+  sub: string
+  email?: string
+  email_verified?: boolean
+  name?: string
+  picture?: string
+}
+
+interface OidcSettings {
+  enabled: boolean
+  issuer: string
+  clientId: string
+  clientSecret: string
+  buttonText: string
+}
+
+export function isOidcProviderConfigured(oidc: OidcSettings) {
+  return Boolean(
+    oidc.enabled && oidc.issuer && oidc.clientId && oidc.clientSecret
+  )
+}
+
+function buildOidcProvider(oidc: OidcSettings): OAuthConfig<OidcRawProfile> {
+  return {
+    id: 'oidc',
+    name: oidc.buttonText || 'SSO',
+    type: 'oauth',
+    wellKnown: `${trimTrailingSlashes(oidc.issuer)}/.well-known/openid-configuration`,
+    clientId: oidc.clientId,
+    clientSecret: oidc.clientSecret,
+    authorization: { params: { scope: 'openid email profile' } },
+    idToken: true,
+    checks: ['pkce', 'state'],
+    async profile(profile) {
+      return {
+        id: profile.sub,
+        name: profile.name ?? null,
+        email: profile.email ?? null,
+        image: profile.picture ?? null,
+      }
+    },
+  }
+}
+
+export async function getAuthOptions(): Promise<NextAuthOptions> {
+  const config = await getConfig()
+  const oidc = config.settings.general.oidc
+
+  const providers = [...authOptions.providers]
+  if (isOidcProviderConfigured(oidc)) {
+    providers.push(buildOidcProvider(oidc))
+  }
+
+  return { ...authOptions, providers }
 }

--- a/lib/auth/oidc-error-messages.ts
+++ b/lib/auth/oidc-error-messages.ts
@@ -1,0 +1,17 @@
+const oidcErrorMessages: Record<string, string> = {
+  OidcNoEmail:
+    "Your identity provider didn't share an email address, so we can't sign you in.",
+  OidcAccountExists:
+    'An account with this email already exists and linking is disabled. Contact an admin.',
+  OidcNotProvisioned:
+    'No local Flare account found matching this OIDC account and automatic sign-up is disabled. Contact an admin.',
+  OidcEmailUnverified:
+    "Your identity provider hasn't verified this email address, so we can't link it to an existing account. Contact an admin.",
+}
+
+export function getOidcErrorMessage(errorCode: string) {
+  return (
+    oidcErrorMessages[errorCode] ||
+    'Sign-in with SSO failed. Please try again or contact an admin.'
+  )
+}

--- a/lib/auth/oidc-resolve-user.ts
+++ b/lib/auth/oidc-resolve-user.ts
@@ -96,6 +96,7 @@ export async function resolveOidcUser(
       name: profile.name || profile.email!.split('@')[0],
       image: profile.picture,
       oidcSubject: profile.sub,
+      emailVerified: profile.email_verified === true ? new Date() : undefined,
     })
   )
 

--- a/lib/auth/oidc-resolve-user.ts
+++ b/lib/auth/oidc-resolve-user.ts
@@ -63,6 +63,10 @@ export async function resolveOidcUser(
     return { ok: false, reason: 'no_email' }
   }
 
+  if (config.requireEmailVerified && profile.email_verified !== true) {
+    return { ok: false, reason: 'email_unverified' }
+  }
+
   const existingByEmail = await prisma.user.findUnique({
     where: { email: profile.email },
     select: userSelect,
@@ -71,10 +75,6 @@ export async function resolveOidcUser(
   if (existingByEmail) {
     if (!config.allowLinking) {
       return { ok: false, reason: 'account_exists' }
-    }
-
-    if (config.requireEmailVerified && profile.email_verified !== true) {
-      return { ok: false, reason: 'email_unverified' }
     }
 
     const linked = await prisma.user.update({

--- a/lib/auth/oidc-resolve-user.ts
+++ b/lib/auth/oidc-resolve-user.ts
@@ -1,0 +1,121 @@
+import { UserRole } from '@prisma/client'
+
+import { prisma } from '@/lib/database/prisma'
+import { createUser } from '@/lib/users/create-user'
+
+export interface OidcProfile {
+  sub: string
+  email?: string | null
+  email_verified?: boolean | null
+  name?: string | null
+  picture?: string | null
+}
+
+export interface OidcConfig {
+  autoProvision: boolean
+  allowLinking: boolean
+  requireEmailVerified: boolean
+}
+
+export interface ResolvedOidcUser {
+  id: string
+  name: string
+  email: string
+  image: string | null
+  role: UserRole
+  sessionVersion: number
+}
+
+export type OidcResolveResult =
+  | { ok: true; user: ResolvedOidcUser }
+  | {
+      ok: false
+      reason:
+        | 'no_email'
+        | 'account_exists'
+        | 'not_provisioned'
+        | 'email_unverified'
+    }
+
+const userSelect = {
+  id: true,
+  email: true,
+  name: true,
+  role: true,
+  image: true,
+  sessionVersion: true,
+} as const
+
+export async function resolveOidcUser(
+  profile: OidcProfile,
+  config: OidcConfig
+): Promise<OidcResolveResult> {
+  const existingBySubject = await prisma.user.findUnique({
+    where: { oidcSubject: profile.sub },
+    select: userSelect,
+  })
+
+  if (existingBySubject) {
+    return { ok: true, user: toResolvedUser(existingBySubject) }
+  }
+
+  if (!profile.email) {
+    return { ok: false, reason: 'no_email' }
+  }
+
+  const existingByEmail = await prisma.user.findUnique({
+    where: { email: profile.email },
+    select: userSelect,
+  })
+
+  if (existingByEmail) {
+    if (!config.allowLinking) {
+      return { ok: false, reason: 'account_exists' }
+    }
+
+    if (config.requireEmailVerified && profile.email_verified !== true) {
+      return { ok: false, reason: 'email_unverified' }
+    }
+
+    const linked = await prisma.user.update({
+      where: { id: existingByEmail.id },
+      data: { oidcSubject: profile.sub },
+      select: userSelect,
+    })
+
+    return { ok: true, user: toResolvedUser(linked) }
+  }
+
+  if (!config.autoProvision) {
+    return { ok: false, reason: 'not_provisioned' }
+  }
+
+  const created = await prisma.$transaction((tx) =>
+    createUser(tx, {
+      email: profile.email as string,
+      name: profile.name || profile.email!.split('@')[0],
+      image: profile.picture,
+      oidcSubject: profile.sub,
+    })
+  )
+
+  return { ok: true, user: toResolvedUser(created) }
+}
+
+function toResolvedUser(user: {
+  id: string
+  email: string | null
+  name: string | null
+  role: UserRole
+  image: string | null
+  sessionVersion: number
+}): ResolvedOidcUser {
+  return {
+    id: user.id,
+    email: user.email || '',
+    name: user.name || '',
+    image: user.image,
+    role: user.role,
+    sessionVersion: user.sessionVersion,
+  }
+}

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -72,7 +72,7 @@ export const configSchema = z.object({
         allowLinking: z.boolean().default(true),
         requireEmailVerified: z.boolean().default(true),
         enforceSso: z.boolean().default(false),
-      }),
+      }).default({}),
     }),
     appearance: z.object({
       theme: z.string(),

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -62,6 +62,17 @@ export const configSchema = z.object({
       ocr: z.object({
         enabled: z.boolean().default(true),
       }),
+      oidc: z.object({
+        enabled: z.boolean().default(false),
+        issuer: z.string().default(''),
+        clientId: z.string().default(''),
+        clientSecret: z.string().default(''),
+        buttonText: z.string().default('Sign in with SSO'),
+        autoProvision: z.boolean().default(true),
+        allowLinking: z.boolean().default(true),
+        requireEmailVerified: z.boolean().default(true),
+        enforceSso: z.boolean().default(false),
+      }),
     }),
     appearance: z.object({
       theme: z.string(),
@@ -116,6 +127,17 @@ export const DEFAULT_CONFIG: FlareConfig = {
       },
       ocr: {
         enabled: true,
+      },
+      oidc: {
+        enabled: false,
+        issuer: '',
+        clientId: '',
+        clientSecret: '',
+        buttonText: 'Sign in with SSO',
+        autoProvision: true,
+        allowLinking: true,
+        requireEmailVerified: true,
+        enforceSso: false,
       },
     },
     appearance: {
@@ -240,6 +262,10 @@ export async function updateConfig(
           ocr: {
             ...currentConfig.settings.general.ocr,
             ...(newConfig.settings?.general?.ocr || {}),
+          },
+          oidc: {
+            ...currentConfig.settings.general.oidc,
+            ...(newConfig.settings?.general?.oidc || {}),
           },
         },
         appearance: {

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -62,17 +62,19 @@ export const configSchema = z.object({
       ocr: z.object({
         enabled: z.boolean().default(true),
       }),
-      oidc: z.object({
-        enabled: z.boolean().default(false),
-        issuer: z.string().default(''),
-        clientId: z.string().default(''),
-        clientSecret: z.string().default(''),
-        buttonText: z.string().default('Sign in with SSO'),
-        autoProvision: z.boolean().default(true),
-        allowLinking: z.boolean().default(true),
-        requireEmailVerified: z.boolean().default(true),
-        enforceSso: z.boolean().default(false),
-      }).default({}),
+      oidc: z
+        .object({
+          enabled: z.boolean().default(false),
+          issuer: z.string().default(''),
+          clientId: z.string().default(''),
+          clientSecret: z.string().default(''),
+          buttonText: z.string().default('Sign in with SSO'),
+          autoProvision: z.boolean().default(true),
+          allowLinking: z.boolean().default(true),
+          requireEmailVerified: z.boolean().default(true),
+          enforceSso: z.boolean().default(false),
+        })
+        .default({}),
     }),
     appearance: z.object({
       theme: z.string(),

--- a/lib/users/create-user.ts
+++ b/lib/users/create-user.ts
@@ -1,0 +1,67 @@
+import { Prisma, User, UserRole } from '@prisma/client'
+import { nanoid } from 'nanoid'
+import { v4 as uuidv4 } from 'uuid'
+
+type TransactionClient = Prisma.TransactionClient
+
+function generateUrlId() {
+  const alphabet = '23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+  return nanoid(5)
+    .split('')
+    .map((char) => {
+      const index = Math.floor((alphabet.length * char.charCodeAt(0)) / 256)
+      return alphabet[index]
+    })
+    .join('')
+}
+
+export async function generateUniqueUrlId(tx: TransactionClient) {
+  let urlId = generateUrlId()
+  let isUnique = false
+  while (!isUnique) {
+    const existing = await tx.user.findUnique({ where: { urlId } })
+    if (!existing) {
+      isUnique = true
+    } else {
+      urlId = generateUrlId()
+    }
+  }
+  return urlId
+}
+
+interface CreateUserInput {
+  email: string
+  name: string
+  image?: string | null
+  password?: string
+  oidcSubject?: string
+  role?: UserRole
+  emailVerified?: Date
+}
+
+export async function createUser(
+  tx: TransactionClient,
+  input: CreateUserInput
+): Promise<User> {
+  const urlId = await generateUniqueUrlId(tx)
+
+  let role = input.role
+  if (!role) {
+    const userCount = await tx.user.count()
+    role = userCount === 0 ? 'ADMIN' : 'USER'
+  }
+
+  return tx.user.create({
+    data: {
+      email: input.email,
+      name: input.name,
+      image: input.image,
+      password: input.password,
+      oidcSubject: input.oidcSubject,
+      emailVerified: input.emailVerified,
+      urlId,
+      role,
+      uploadToken: uuidv4(),
+    },
+  })
+}

--- a/prisma/migrations/20260816210646_add_oidc_subject/migration.sql
+++ b/prisma/migrations/20260816210646_add_oidc_subject/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "oidcSubject" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_oidcSubject_key" ON "User"("oidcSubject");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   updatedAt                   DateTime       @updatedAt
   storageUsed                 Float          @default(0)
   sessionVersion              Int            @default(1)
+  oidcSubject                 String?        @unique
   vanityId                    String?        @unique
   urlId                       String         @unique
   uploadToken                 String         @unique


### PR DESCRIPTION
Great app, thanks for your work! I'd like SSO support before deploying to my home-lab, so I took the liberty of adding it. Hopefully this isn't too impactful, tried to minimize scope creep while not leaving easy fixes out of touched code.

## Description

- feat(auth): single sign-on support with OIDC
- chore(auth): de-duplicate user creation functions

---

## Type

- **feat** — new feature or functionality

---

## Issues
fixes #134

---

## Details

Adds OIDC as an alternative sign-in method, configured via admin settings. Adds an oidcSubject column on User to link IdP identities to local accounts with a migration. Security settings to enforce verified emails with IdP and to disable linking accounts / auto-provision as desired. Also allows users to change SSO sign-on button text.

## Testing

I spun up my IdP of choice, authentik, as a local docker container and used it to run the tests below.

In authentik, added using normal OIDC flow from application. Added supported redirect URI for auth of `http://localhost:3000/api/auth/callback/oidc`

<img width="1361" height="184" alt="oidc-settings-disabled" src="https://github.com/user-attachments/assets/2ff0c656-b71b-4e5e-97dd-c410dc841c93" />

Fig 1. oidc settings page when disabled

<img width="1442" height="970" alt="oidc-settings" src="https://github.com/user-attachments/assets/5d7f47fc-12a2-407d-bbf2-0fc0c7f5f8e4" />

Fig 2. odic settings page when configured properly

<img width="688" height="931" alt="oidc-only-local-bypass" src="https://github.com/user-attachments/assets/d8a71e60-094c-4841-94ef-c5b7b6f3baa1" />

Fig 3. lockout prevention page when auto-login enabled (really just an extra fail-safe since I link to this on failed auto-login)

<img width="531" height="513" alt="oidc-disabled-auto-provision-denies-login" src="https://github.com/user-attachments/assets/bb9c6475-fe52-4369-a373-3c9ff07eb9b5" />

Fig 4. account is not created when auto-provision disabled (error as shown with auto-login enabled)

<img width="461" height="794" alt="oidc-unverified-email-no-autologin" src="https://github.com/user-attachments/assets/21897b5c-49e5-42dc-9b69-7c422aaf5464" />

Fig 5. oidc error when IdP is does not declare the user has a verified email  (error as shown with auto-login disabled)


Additionally, verified the following cases:
- SSO login is not enabled until fully configured, e.g. issuer/clientId/clientSecret must be present.
- Option to disable email verification works.

And added some tests for the new code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added configurable OIDC/SSO authentication.
- Added settings for issuer credentials, button text, automatic login, user provisioning, account linking, and email verification.
- Added SSO sign-in, automatic redirects, retry controls, and clear error messages.
- Supports recognizing existing accounts and creating new users through SSO.

## Improvements
- Centralized user creation for consistent roles and account metadata across registration, setup, and administrative user creation.

## Tests
- Added coverage for OIDC configuration validation, error handling, account linking, provisioning, and login scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->